### PR TITLE
TWILL-175 Avoid caching YarnClient

### DIFF
--- a/twill-core/src/main/java/org/apache/twill/internal/ProcessController.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/ProcessController.java
@@ -24,7 +24,7 @@ import org.apache.twill.common.Cancellable;
  *
  * @param <R> Report type.
  */
-public interface ProcessController<R> extends Cancellable {
+public interface ProcessController<R> extends AutoCloseable, Cancellable {
 
   R getReport();
 

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunnableProcessLauncher.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunnableProcessLauncher.java
@@ -76,6 +76,11 @@ public final class RunnableProcessLauncher extends AbstractYarnProcessLauncher<Y
 
     return new ProcessController<R>() {
       @Override
+      public void close() throws Exception {
+        // no-op
+      }
+
+      @Override
       public R getReport() {
         // No reporting support for runnable launch yet.
         return null;

--- a/twill-yarn/src/main/java/org/apache/twill/internal/yarn/YarnAppClient.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/yarn/YarnAppClient.java
@@ -17,7 +17,6 @@
  */
 package org.apache.twill.internal.yarn;
 
-import com.google.common.util.concurrent.Service;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.twill.api.TwillSpecification;
@@ -31,7 +30,7 @@ import javax.annotation.Nullable;
 /**
  * Interface for launching Yarn application from client.
  */
-public interface YarnAppClient extends Service {
+public interface YarnAppClient {
 
   /**
    * Creates a {@link ProcessLauncher} for launching the application represented by the given spec. If scheduler queue

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
@@ -154,7 +154,7 @@ final class YarnTwillController extends AbstractTwillController implements Twill
     }
 
     // Poll application status from yarn
-    try {
+    try (ProcessController<YarnApplicationReport> processController = this.processController) {
       Stopwatch stopWatch = new Stopwatch();
       stopWatch.start();
       long maxTime = TimeUnit.MILLISECONDS.convert(Constants.APPLICATION_MAX_STOP_SECONDS, TimeUnit.SECONDS);

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
@@ -319,7 +319,6 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
   }
 
   private void startUp() throws Exception {
-    yarnAppClient.startAndWait();
     zkClientService.startAndWait();
 
     // Create the root node, so that the namespace root would get created if it is missing
@@ -357,7 +356,6 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
     }
     watchCancellable.cancel();
     zkClientService.stopAndWait();
-    yarnAppClient.stopAndWait();
   }
 
   private Cancellable watchLiveApps() {

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/TwillTester.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/TwillTester.java
@@ -110,12 +110,10 @@ public class TwillTester extends ExternalResource {
     twillRunner.start();
 
     yarnAppClient = new VersionDetectYarnAppClientFactory().create(conf);
-    yarnAppClient.startAndWait();
   }
 
   @Override
   protected void after() {
-    stopQuietly(yarnAppClient);
     try {
       twillRunner.stop();
     } catch (Exception e) {


### PR DESCRIPTION
Avoid caching a YarnClient, since each YarnClient is fixed to a particular UserGroupInformation.

Note: The diff is very similar as to the changes made to the same file in:
https://github.com/caskdata/cdap/pull/6024/files#diff-41467cacd78ce3eba37c5aa839c4a508
Additional change had to be made to the `addRMToken` method, since that doesn't exist in the CDAP repo.

https://issues.apache.org/jira/browse/TWILL-175