### PR TITLE
TWILL-185 Allow user to avoid scheduling the LocationSecureStoreUpdater.

### DIFF
--- a/twill-core/src/main/java/org/apache/twill/internal/Configs.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/Configs.java
@@ -31,6 +31,11 @@ public final class Configs {
      */
     public static final String JAVA_RESERVED_MEMORY_MB = "twill.java.reserved.memory.mb";
 
+    /**
+     * Set this to false to disable the secure store updates done by default.
+     */
+    public static final String SECURE_STORE_UPDATE_LOCATION_ENABLED = "twill.secure.store.update.location.enabled";
+
     private Keys() {
     }
   }

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
@@ -65,6 +65,7 @@ import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.FileContextLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
+import org.apache.twill.internal.Configs;
 import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.ProcessController;
 import org.apache.twill.internal.RunIds;
@@ -330,8 +331,9 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
     watchCancellable = watchLiveApps();
     liveInfos = createLiveInfos();
 
+    boolean enableSecureStoreUpdate = yarnConfig.getBoolean(Configs.Keys.SECURE_STORE_UPDATE_LOCATION_ENABLED, true);
     // Schedule an updater for updating HDFS delegation tokens
-    if (UserGroupInformation.isSecurityEnabled()) {
+    if (UserGroupInformation.isSecurityEnabled() && enableSecureStoreUpdate) {
       long renewalInterval = yarnConfig.getLong(DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_RENEW_INTERVAL_KEY,
                                                 DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT);
       // Schedule it five minutes before it expires.


### PR DESCRIPTION
This will allow the use case of user scheduling their own secure store updates.
As a workaround, for example:
https://github.com/caskdata/cdap/pull/6380/commits/e77b9ac1fa6c9176a49cb27d6118e2d3065b93cd#diff-832334ca819881b7884d50946c76ce00L332

It will also alleviate some of the issues described in https://issues.apache.org/jira/browse/TWILL-109.

https://issues.apache.org/jira/browse/TWILL-185