### PR TITLE
Fix a ClassCastException in YarnUtils.addDelegationTokens.

### DIFF
--- a/twill-yarn/src/main/java/org/apache/twill/internal/yarn/YarnUtils.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/yarn/YarnUtils.java
@@ -165,7 +165,7 @@ public class YarnUtils {
         tokens = ImmutableList.copyOf(fsTokens);
       }
     } else if (factory instanceof FileContextLocationFactory) {
-      FileContext fc = ((FileContextLocationFactory) locationFactory).getFileContext();
+      FileContext fc = ((FileContextLocationFactory) factory).getFileContext();
       tokens = fc.getDelegationTokens(new Path(locationFactory.create("/").toURI()), renewer);
     }
 


### PR DESCRIPTION
Earlier in the method, we `unwrap` the `locationFactory`. Also, the `instanceof` check is on the unwrapped object. So, we should cast the unwrapped object, not the original object.

Example exception:
```
java.lang.ClassCastException: org.apache.twill.filesystem.LocationFactories$1 cannot be cast to org.apache.twill.filesystem.FileContextLocationFactory
        at org.apache.twill.internal.yarn.YarnUtils.addDelegationTokens(YarnUtils.java:168) ~[org.apache.twill.twill-yarn-0.8.0-SNAPSHOT.jar:0.8.0-SNAPSHOT]
```