### PR TITLE
TWILL-138 TWILL-195 Runtime log level change

### DIFF
--- a/twill-api/src/main/java/org/apache/twill/api/ResourceReport.java
+++ b/twill-api/src/main/java/org/apache/twill/api/ResourceReport.java
@@ -17,6 +17,8 @@
  */
 package org.apache.twill.api;
 
+import org.apache.twill.api.logging.LogEntry;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -61,4 +63,19 @@ public interface ResourceReport {
    * @return list of services of the application master.
    */
   List<String> getServices();
+
+  /**
+   * Get the map of the log level arguments of the twill application.
+   *
+   * @return the map of the log level arguments of the twill application
+   */
+  Map<String, Map<String, LogEntry.Level>> getLogLevelArguments();
+
+  /**
+   * Update the log level arguments for the specified twill runnable.
+   *
+   * @param runnableName name of the runnable.
+   * @param logLevelArguments map of the log level arguments to be updated.
+   */
+  void updateLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelArguments);
 }

--- a/twill-api/src/main/java/org/apache/twill/api/TwillController.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillController.java
@@ -91,9 +91,28 @@ public interface TwillController extends ServiceController {
    */
   Future<String> restartInstances(String runnable, int instanceId, int... moreInstanceIds);
 
+  /**
+   * Set the root log level for Twill applications running in a container.
+   *
+   * @param logLevel The log level for the root logger to change.
+   * @return A {@link Future} that will be completed when the set log level operation has been done.
+   */
   Future<String> setLogLevel(LogEntry.Level logLevel);
 
+  /**
+   * Set the log levels for requested logger names for Twill applications running in a container.
+   *
+   * @param logLevelAppArgs The {@link Map} contains the requested logger names and log levels that need to be set.
+   * @return A {@link Future} that will be completed when the set log level operation has been done.
+   */
   Future<String> setLogLevel(Map<String, LogEntry.Level> logLevelAppArgs);
 
+  /**
+   * Set the log levels for requested logger names for a {@link TwillRunnable}.
+   *
+   * @param runnableName The name of the runnable to set the log level.
+   * @param logLevels The {@link Map} contains the requested logger name and log level that need to be changed.
+   * @return A {@link Future} that will be completed when the set log level operation has been done.
+   */
   Future<String> setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevels);
 }

--- a/twill-api/src/main/java/org/apache/twill/api/TwillController.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillController.java
@@ -17,6 +17,7 @@
  */
 package org.apache.twill.api;
 
+import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.api.logging.LogHandler;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.ServiceDiscovered;
@@ -89,4 +90,10 @@ public interface TwillController extends ServiceController {
    * @return A {@link Future} that will be completed when the restart operation has been done.
    */
   Future<String> restartInstances(String runnable, int instanceId, int... moreInstanceIds);
+
+  Future<String> setLogLevel(LogEntry.Level logLevel);
+
+  Future<String> setLogLevel(Map<String, LogEntry.Level> logLevelAppArgs);
+
+  Future<String> setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevels);
 }

--- a/twill-api/src/main/java/org/apache/twill/api/TwillPreparer.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillPreparer.java
@@ -235,6 +235,10 @@ public interface TwillPreparer {
    */
   TwillPreparer setLogLevel(LogEntry.Level logLevel);
 
+  TwillPreparer setLogLevel(Map<String, LogEntry.Level> logLevelAppArgs);
+
+  TwillPreparer setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelRunnableArgs);
+
   /**
    * Starts the application.
    * @return A {@link TwillController} for controlling the running application.

--- a/twill-api/src/main/java/org/apache/twill/api/TwillPreparer.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillPreparer.java
@@ -227,7 +227,7 @@ public interface TwillPreparer {
   TwillPreparer addSecureStore(SecureStore secureStore);
 
   /**
-   * Set the log level for Twill applications running in a container.
+   * Set the root log level for Twill applications running in a container.
    *
    * @param logLevel the {@link LogEntry.Level} that should be set.
    *                 The level match the {@code Logback} levels.
@@ -235,8 +235,21 @@ public interface TwillPreparer {
    */
   TwillPreparer setLogLevel(LogEntry.Level logLevel);
 
+  /**
+   * Set the log levels for requested logger names for Twill applications running in a container.
+   *
+   * @param logLevelAppArgs The {@link Map} contains the requested logger names and log levels that need to be set.
+   * @return This {@link TwillPreparer}.
+   */
   TwillPreparer setLogLevel(Map<String, LogEntry.Level> logLevelAppArgs);
 
+  /**
+   * Set the log levels for requested logger names for a {@link TwillRunnable}.
+   *
+   * @param runnableName The name of the runnable to set the log level.
+   * @param logLevelRunnableArgs The {@link Map} contains the requested logger names and log levels that need to be set.
+   * @return This {@link TwillPreparer}.
+   */
   TwillPreparer setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelRunnableArgs);
 
   /**

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRunResources.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRunResources.java
@@ -66,10 +66,11 @@ public interface TwillRunResources {
   /**
    * @return the enabled log level arguments for the container where the runnable is running in.
    */
-  Map<String, String> getLogLevelArguments();
+  Map<String, LogEntry.Level> getLogLevelArguments();
 
   /**
    * Update the log level arguments for the container where the runnable is running in.
+   * @param logLevelArguments
    */
-  void updateLogLevel(Map<String, String> logLevelArguments);
+  void updateLogLevel(Map<String, LogEntry.Level> logLevelArguments);
 }

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRunResources.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRunResources.java
@@ -64,12 +64,12 @@ public interface TwillRunResources {
   LogEntry.Level getRootLogLevel();
 
   /**
-   *
+   * @return the enabled log level arguments for the container where the runnable is running in.
    */
   Map<String, String> getLogLevelArguments();
 
   /**
-   *
+   * Update the log level arguments for the container where the runnable is running in.
    */
   void updateLogLevel(Map<String, String> logLevelArguments);
 }

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRunResources.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRunResources.java
@@ -19,6 +19,8 @@ package org.apache.twill.api;
 
 import org.apache.twill.api.logging.LogEntry;
 
+import java.util.Map;
+
 /**
  * Information about the container the {@link TwillRunnable}
  * is running in.
@@ -59,6 +61,15 @@ public interface TwillRunResources {
   /**
    * @return the enabled log level for the container where the runnable is running in.
    */
-  LogEntry.Level getLogLevel();
+  LogEntry.Level getRootLogLevel();
 
+  /**
+   *
+   */
+  Map<String, String> getLogLevelArguments();
+
+  /**
+   *
+   */
+  void updateLogLevel(Map<String, String> logLevelArguments);
 }

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.api;
+
+/**
+ *
+ */
+public interface TwillRuntimeSpecification {
+
+  TwillSpecification getTwillSpecification();
+
+  String getFsUser();
+
+  String getTwillAppDir();
+
+  String getZkConnectStr();
+
+  String getTwillRunId();
+
+  String getTwillAppName();
+
+  String getReservedMemory();
+
+  String getRmSchedulerAddr();
+
+  String getLogLevel();
+
+  void setLogLevel(String logLevel);
+}

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
@@ -39,6 +39,4 @@ public interface TwillRuntimeSpecification {
   String getRmSchedulerAddr();
 
   String getLogLevel();
-
-  void setLogLevel(String logLevel);
 }

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
@@ -34,7 +34,7 @@ public interface TwillRuntimeSpecification {
 
   String getZkConnectStr();
 
-  String getTwillRunId();
+  String getTwillAppRunId();
 
   String getTwillAppName();
 

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
@@ -22,7 +22,7 @@ import org.apache.twill.api.logging.LogEntry;
 import java.util.Map;
 
 /**
- *
+ * Represents runtime specification of a {@link TwillApplication}.
  */
 public interface TwillRuntimeSpecification {
 

--- a/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillRuntimeSpecification.java
@@ -17,6 +17,10 @@
  */
 package org.apache.twill.api;
 
+import org.apache.twill.api.logging.LogEntry;
+
+import java.util.Map;
+
 /**
  *
  */
@@ -39,4 +43,6 @@ public interface TwillRuntimeSpecification {
   String getRmSchedulerAddr();
 
   String getLogLevel();
+
+  Map<String, Map<String, LogEntry.Level>> getLogLevelArguments();
 }

--- a/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRunResources.java
+++ b/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRunResources.java
@@ -35,17 +35,18 @@ public class DefaultTwillRunResources implements TwillRunResources {
   private final int memoryMB;
   private final String host;
   private final Integer debugPort;
-  private final Map<String, String> logLevelArguments;
+  private final Map<String, LogEntry.Level> logLevelArguments;
   private Level rootLogLevel;
 
   public DefaultTwillRunResources(int instanceId, String containerId, int cores, int memoryMB,
                                   String host, Integer debugPort, Level rootLogLevel) {
-    this(instanceId, containerId, cores, memoryMB, host, debugPort, rootLogLevel, new HashMap<String, String>());
+    this(instanceId, containerId, cores, memoryMB, host, debugPort, rootLogLevel,
+         new HashMap<String, LogEntry.Level>());
   }
 
   public DefaultTwillRunResources(int instanceId, String containerId, int cores, int memoryMB,
                                   String host, Integer debugPort,
-                                  Level rootLogLevel, Map<String, String> logLevelArguments) {
+                                  Level rootLogLevel, Map<String, LogEntry.Level> logLevelArguments) {
     this.instanceId = instanceId;
     this.containerId = containerId;
     this.virtualCores = cores;
@@ -108,14 +109,14 @@ public class DefaultTwillRunResources implements TwillRunResources {
   }
 
   @Override
-  public Map<String, String> getLogLevelArguments() {
+  public Map<String, LogEntry.Level> getLogLevelArguments() {
     return logLevelArguments;
   }
 
   @Override
-  public void updateLogLevel(Map<String, String> logLevelArguments) {
+  public void updateLogLevel(Map<String, Level> logLevelArguments) {
     if (logLevelArguments.containsKey(Logger.ROOT_LOGGER_NAME)) {
-      this.rootLogLevel = LogEntry.Level.valueOf(logLevelArguments.get(Logger.ROOT_LOGGER_NAME));
+      this.rootLogLevel = logLevelArguments.get(Logger.ROOT_LOGGER_NAME);
     }
     this.logLevelArguments.putAll(logLevelArguments);
   }

--- a/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRunResources.java
+++ b/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRunResources.java
@@ -21,11 +21,9 @@ import org.apache.twill.api.TwillRunResources;
 import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.api.logging.LogEntry.Level;
 import org.slf4j.Logger;
-import sun.rmi.runtime.Log;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  *  Straightforward implementation of {@link org.apache.twill.api.TwillRunResources}.
@@ -39,7 +37,6 @@ public class DefaultTwillRunResources implements TwillRunResources {
   private final Integer debugPort;
   private final Map<String, String> logLevelArguments;
   private Level rootLogLevel;
-
 
   public DefaultTwillRunResources(int instanceId, String containerId, int cores, int memoryMB,
                                   String host, Integer debugPort, Level rootLogLevel) {
@@ -120,7 +117,6 @@ public class DefaultTwillRunResources implements TwillRunResources {
     if (logLevelArguments.containsKey(Logger.ROOT_LOGGER_NAME)) {
       this.rootLogLevel = LogEntry.Level.valueOf(logLevelArguments.get(Logger.ROOT_LOGGER_NAME));
     }
-    this.logLevelArguments.clear();
     this.logLevelArguments.putAll(logLevelArguments);
   }
 

--- a/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
@@ -77,7 +77,7 @@ public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecificati
   }
 
   @Override
-  public String getTwillRunId() {
+  public String getTwillAppRunId() {
     return twillRunId;
   }
 

--- a/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
@@ -24,7 +24,7 @@ import org.apache.twill.api.logging.LogEntry;
 import java.util.Map;
 
 /**
- *
+ * Straightforward implementation of {@link org.apache.twill.api.TwillRuntimeSpecification}.
  */
 public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecification {
 

--- a/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
@@ -19,6 +19,9 @@ package org.apache.twill.internal;
 
 import org.apache.twill.api.TwillRuntimeSpecification;
 import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.api.logging.LogEntry;
+
+import java.util.Map;
 
 /**
  *
@@ -35,10 +38,12 @@ public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecificati
   private final String reservedMemory;
   private final String rmSchedulerAddr;
   private final String logLevel;
+  private final Map<String, Map<String, LogEntry.Level>> logLevelArguments;
 
   public DefaultTwillRuntimeSpecification(TwillSpecification twillSpecification, String fsUser, String twillAppDir,
                                           String zkConnectStr, String twillRunId, String twillAppName,
-                                          String reservedMemory, String rmSchedulerAddr, String logLevel) {
+                                          String reservedMemory, String rmSchedulerAddr, String logLevel,
+                                          Map<String, Map<String, LogEntry.Level>> logLevelArguments) {
     this.twillSpecification = twillSpecification;
     this.fsUser = fsUser;
     this.twillAppDir = twillAppDir;
@@ -48,6 +53,7 @@ public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecificati
     this.reservedMemory = reservedMemory;
     this.rmSchedulerAddr = rmSchedulerAddr;
     this.logLevel = logLevel;
+    this.logLevelArguments = logLevelArguments;
   }
 
   @Override
@@ -93,5 +99,10 @@ public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecificati
   @Override
   public String getLogLevel() {
     return logLevel;
+  }
+
+  @Override
+  public Map<String, Map<String, LogEntry.Level>> getLogLevelArguments() {
+    return logLevelArguments;
   }
 }

--- a/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.internal;
+
+import org.apache.twill.api.TwillRuntimeSpecification;
+import org.apache.twill.api.TwillSpecification;
+
+/**
+ *
+ */
+public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecification {
+
+  private final TwillSpecification twillSpecification;
+
+  private final String fsUser;
+  private final String twillAppDir;
+  private final String zkConnectStr;
+  private final String twillRunId;
+  private final String twillAppName;
+  private final String reservedMemory;
+  private final String rmSchedulerAddr;
+  private String logLevel;
+
+  public DefaultTwillRuntimeSpecification(TwillSpecification twillSpecification, String fsUser, String twillAppDir,
+                                          String zkConnectStr, String twillRunId, String twillAppName,
+                                          String reservedMemory, String rmSchedulerAddr, String logLevel) {
+    this.twillSpecification = twillSpecification;
+    this.fsUser = fsUser;
+    this.twillAppDir = twillAppDir;
+    this.zkConnectStr = zkConnectStr;
+    this.twillRunId = twillRunId;
+    this.twillAppName = twillAppName;
+    this.reservedMemory = reservedMemory;
+    this.rmSchedulerAddr = rmSchedulerAddr;
+    this.logLevel = logLevel;
+  }
+
+  @Override
+  public TwillSpecification getTwillSpecification() {
+    return twillSpecification;
+  }
+
+  @Override
+  public String getFsUser() {
+    return fsUser;
+  }
+
+  @Override
+  public String getTwillAppDir() {
+    return twillAppDir;
+  }
+
+  @Override
+  public String getZkConnectStr() {
+    return zkConnectStr;
+  }
+
+  @Override
+  public String getTwillRunId() {
+    return twillRunId;
+  }
+
+  @Override
+  public String getTwillAppName() {
+    return twillAppName;
+  }
+
+  @Override
+  public String getReservedMemory() {
+    return reservedMemory;
+  }
+
+  @Override
+  public String getRmSchedulerAddr() {
+    return rmSchedulerAddr;
+  }
+
+  @Override
+  public String getLogLevel() {
+    return logLevel;
+  }
+
+  @Override
+  public void setLogLevel(String logLevel) {
+    this.logLevel = logLevel;
+  }
+
+}

--- a/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
+++ b/twill-api/src/main/java/org/apache/twill/internal/DefaultTwillRuntimeSpecification.java
@@ -34,7 +34,7 @@ public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecificati
   private final String twillAppName;
   private final String reservedMemory;
   private final String rmSchedulerAddr;
-  private String logLevel;
+  private final String logLevel;
 
   public DefaultTwillRuntimeSpecification(TwillSpecification twillSpecification, String fsUser, String twillAppDir,
                                           String zkConnectStr, String twillRunId, String twillAppName,
@@ -94,10 +94,4 @@ public class DefaultTwillRuntimeSpecification implements TwillRuntimeSpecificati
   public String getLogLevel() {
     return logLevel;
   }
-
-  @Override
-  public void setLogLevel(String logLevel) {
-    this.logLevel = logLevel;
-  }
-
 }

--- a/twill-common/src/main/java/org/apache/twill/internal/Constants.java
+++ b/twill-common/src/main/java/org/apache/twill/internal/Constants.java
@@ -92,6 +92,7 @@ public final class Constants {
    */
   public static final class SystemMessages {
     public static final String LOG_LEVEL = "system.log.level";
+    public static final String LOG_ALL_RUNNABLES = "ALL";
   }
 
   private Constants() {

--- a/twill-common/src/main/java/org/apache/twill/internal/Constants.java
+++ b/twill-common/src/main/java/org/apache/twill/internal/Constants.java
@@ -79,7 +79,7 @@ public final class Constants {
   }
 
   /**
-   *
+   * Constants for twill environment variable names.
    */
   public static final class Environments {
 

--- a/twill-common/src/main/java/org/apache/twill/internal/Constants.java
+++ b/twill-common/src/main/java/org/apache/twill/internal/Constants.java
@@ -52,7 +52,7 @@ public final class Constants {
   public static final String RESTART_RUNNABLES_INSTANCES = "restartRunnablesInstances";
 
   /**
-   * Common ZK paths constants
+   * Common ZK paths constants.
    */
   public static final String DISCOVERY_PATH_PREFIX = "/discoverable";
   public static final String INSTANCES_PATH_PREFIX = "/instances";
@@ -78,10 +78,20 @@ public final class Constants {
     }
   }
 
+  /**
+   *
+   */
   public static final class Environments {
 
     public static final String TWILL_FS_USER = "TWILL_FS_USER";
     public static final String TWILL_APP_NAME = "TWILL_APP_NAME";
+  }
+
+  /**
+   * Constants for logLevel system messages.
+   */
+  public static final class SystemMessages {
+    public static final String LOG_LEVEL = "system.log.level";
   }
 
   private Constants() {

--- a/twill-common/src/main/java/org/apache/twill/internal/Constants.java
+++ b/twill-common/src/main/java/org/apache/twill/internal/Constants.java
@@ -78,6 +78,12 @@ public final class Constants {
     }
   }
 
+  public static final class Environments {
+
+    public static final String TWILL_FS_USER = "TWILL_FS_USER";
+    public static final String TWILL_APP_NAME = "TWILL_APP_NAME";
+  }
+
   private Constants() {
   }
 }

--- a/twill-core/src/main/java/org/apache/twill/internal/AbstractTwillController.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/AbstractTwillController.java
@@ -53,15 +53,12 @@ import org.apache.twill.zookeeper.ZKClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 /**
@@ -90,8 +87,8 @@ public abstract class AbstractTwillController extends AbstractZKServiceControlle
     if (!logHandlers.isEmpty()) {
       kafkaClient.startAndWait();
       logCancellable = kafkaClient.getConsumer().prepare()
-        .addFromBeginning(Constants.LOG_TOPIC, 0)
-        .consume(new LogMessageCallback(logHandlers));
+                                  .addFromBeginning(Constants.LOG_TOPIC, 0)
+                                  .consume(new LogMessageCallback(logHandlers));
     }
   }
 
@@ -168,10 +165,26 @@ public abstract class AbstractTwillController extends AbstractZKServiceControlle
 
     return Futures.transform(restartInstances(ImmutableMap.of(runnable, instanceIds)),
                              new Function<Set<String>, String>() {
-                               public String apply(Set<String> input) {
-                                 return runnable;
-                               }
-                             });
+      public String apply(Set<String> input) {
+        return runnable;
+      }
+    });
+  }
+
+  @Override
+  public Future<String> setLogLevel(LogEntry.Level logLevel) {
+    return sendMessage(SystemMessages.setLogLevel(
+      ImmutableMap.of(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME, logLevel)), logLevel.name());
+  }
+
+  @Override
+  public Future<String> setLogLevel(Map<String, LogEntry.Level> logLevelAppArgs) {
+    return sendMessage(SystemMessages.setLogLevel(logLevelAppArgs), logLevelAppArgs.toString());
+  }
+
+  @Override
+  public Future<String> setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelRunnableArgs) {
+    return sendMessage(SystemMessages.setLogLevel(runnableName, logLevelRunnableArgs), runnableName);
   }
 
   private void validateInstanceIds(String runnable, Set<Integer> instanceIds) {
@@ -193,22 +206,6 @@ public abstract class AbstractTwillController extends AbstractZKServiceControlle
         throw new IllegalArgumentException("Unable to find instance id " + instanceId + " for " + runnable);
       }
     }
-  }
-
-  @Override
-  public Future<String> setLogLevel(LogEntry.Level logLevel) {
-    return sendMessage(SystemMessages.setLogLevel(
-      ImmutableMap.of(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME, logLevel)), logLevel.name());
-  }
-
-  @Override
-  public Future<String> setLogLevel(Map<String, LogEntry.Level> logLevelAppArgs) {
-    return sendMessage(SystemMessages.setLogLevel(logLevelAppArgs), logLevelAppArgs.toString());
-  }
-
-  @Override
-  public Future<String> setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelRunnableArgs) {
-    return sendMessage(SystemMessages.setLogLevel(runnableName, logLevelRunnableArgs), runnableName);
   }
 
   private static final class LogMessageCallback implements KafkaConsumer.MessageCallback {

--- a/twill-core/src/main/java/org/apache/twill/internal/DefaultResourceReport.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/DefaultResourceReport.java
@@ -24,9 +24,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.TwillRunResources;
-import org.apache.twill.api.logging.LogEntry;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -151,6 +149,12 @@ public final class DefaultResourceReport implements ResourceReport {
     return services.get();
   }
 
+  /**
+   * Update the log level arguments for the specified twill runnable.
+   *
+   * @param runnableName name of the runnable.
+   * @param logLevelArguments map of the log level arguments to be updated.
+   */
   public void updateLogLevel(String runnableName, Map<String, String> logLevelArguments) {
     if (usedResources.containsKey(runnableName)) {
       for (TwillRunResources resources : usedResources.get(runnableName)) {

--- a/twill-core/src/main/java/org/apache/twill/internal/DefaultResourceReport.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/DefaultResourceReport.java
@@ -24,7 +24,9 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.TwillRunResources;
+import org.apache.twill.api.logging.LogEntry;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -147,6 +149,14 @@ public final class DefaultResourceReport implements ResourceReport {
   @Override
   public List<String> getServices() {
     return services.get();
+  }
+
+  public void updateLogLevel(String runnableName, Map<String, String> logLevelArguments) {
+    if (usedResources.containsKey(runnableName)) {
+      for (TwillRunResources resources : usedResources.get(runnableName)) {
+        resources.updateLogLevel(logLevelArguments);
+      }
+    }
   }
 
   @Override

--- a/twill-core/src/main/java/org/apache/twill/internal/EnvKeys.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/EnvKeys.java
@@ -22,29 +22,17 @@ package org.apache.twill.internal;
  */
 public final class EnvKeys {
 
-  public static final String TWILL_ZK_CONNECT = "TWILL_ZK_CONNECT";
-  public static final String TWILL_APP_RUN_ID = "TWILL_APP_RUN_ID";
   public static final String TWILL_RUN_ID = "TWILL_RUN_ID";
   public static final String TWILL_INSTANCE_ID = "TWILL_INSTANCE_ID";
   public static final String TWILL_INSTANCE_COUNT = "TWILL_INSTANCE_COUNT";
-  public static final String TWILL_RESERVED_MEMORY_MB = "TWILL_RESERVED_MEMORY_MB";
-
-  public static final String TWILL_FS_USER = "TWILL_FS_USER";
 
   /**
    * Cluster filesystem directory for storing twill app related files.
    */
-  public static final String TWILL_APP_DIR = "TWILL_APP_DIR";
-
-  public static final String TWILL_APP_NAME = "TWILL_APP_NAME";
-
-  public static final String TWILL_APP_LOG_LEVEL = "TWILL_APP_LOG_LEVEL";
-
   public static final String TWILL_RUNNABLE_NAME = "TWILL_RUNNABLE_NAME";
 
   public static final String TWILL_LOG_KAFKA_ZK = "TWILL_LOG_KAFKA_ZK";
 
-  public static final String YARN_RM_SCHEDULER_ADDRESS = "YARN_RM_SCHEDULER_ADDRESS";
   public static final String YARN_APP_ID = "YARN_APP_ID";
   public static final String YARN_APP_ID_CLUSTER_TIME = "YARN_APP_ID_CLUSTER_TIME";
   public static final String YARN_APP_ID_STR = "YARN_APP_ID_STR";
@@ -52,6 +40,7 @@ public final class EnvKeys {
   public static final String YARN_CONTAINER_ID = "YARN_CONTAINER_ID";
   public static final String YARN_CONTAINER_HOST = "YARN_CONTAINER_HOST";
   public static final String YARN_CONTAINER_PORT = "YARN_CONTAINER_PORT";
+
   /**
    * Used to inform runnables of their resource usage.
    */

--- a/twill-core/src/main/java/org/apache/twill/internal/TwillContainerLauncher.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/TwillContainerLauncher.java
@@ -136,7 +136,8 @@ public final class TwillContainerLauncher {
     int memory = Resources.computeMaxHeapSize(containerInfo.getMemoryMB(), reservedMemory, Constants.HEAP_MIN_RATIO);
     commandBuilder.add("-Djava.io.tmpdir=tmp",
                        "-Dyarn.container=$" + EnvKeys.YARN_CONTAINER_ID,
-                       "-Dtwill.runnable=$" + EnvKeys.TWILL_APP_NAME + ".$" + EnvKeys.TWILL_RUNNABLE_NAME,
+                       "-Dtwill.runnable=$" + Constants.Environments.TWILL_APP_NAME + ".$" +
+                         EnvKeys.TWILL_RUNNABLE_NAME,
                        "-cp", Constants.Files.LAUNCHER_JAR + ":" + classPath,
                        "-Xmx" + memory + "m");
     if (jvmOpts.getExtraOptions() != null) {

--- a/twill-core/src/main/java/org/apache/twill/internal/json/ResourceReportCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/ResourceReportCodec.java
@@ -27,6 +27,7 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.TwillRunResources;
+import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.internal.DefaultResourceReport;
 
 import java.lang.reflect.Type;
@@ -50,7 +51,9 @@ public final class ResourceReportCodec implements JsonSerializer<ResourceReport>
     json.add("runnableResources", context.serialize(
       src.getResources(), new TypeToken<Map<String, Collection<TwillRunResources>>>() { }.getType()));
     json.add("services", context.serialize(
-      src.getServices(), new TypeToken<List<String>>() {}.getType()));
+      src.getServices(), new TypeToken<List<String>>() { }.getType()));
+    json.add("logLevelArguments", context.serialize(
+      src.getLogLevelArguments(), new TypeToken<Map<String, Map<String, LogEntry.Level>>>() { }.getType()));
     return json;
   }
 
@@ -65,7 +68,9 @@ public final class ResourceReportCodec implements JsonSerializer<ResourceReport>
       jsonObj.get("runnableResources"), new TypeToken<Map<String, Collection<TwillRunResources>>>() { }.getType());
     List<String> services = context.deserialize(
       jsonObj.get("services"), new TypeToken<List<String>>() {}.getType());
+    Map<String, Map<String, LogEntry.Level>> logLevelArguments = context.deserialize(
+      jsonObj.get("logLevelArguments"), new TypeToken<Map<String, Map<String, LogEntry.Level>>>() { }.getType());
 
-    return new DefaultResourceReport(appMasterId, masterResources, resources, services);
+    return new DefaultResourceReport(appMasterId, masterResources, resources, services, logLevelArguments);
   }
 }

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRunResourcesCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRunResourcesCodec.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * Codec for serializing and deserializing a {@link org.apache.twill.api.TwillRunResources} object using json.
  */
 public final class TwillRunResourcesCodec implements JsonSerializer<TwillRunResources>,
-  JsonDeserializer<TwillRunResources> {
+                                              JsonDeserializer<TwillRunResources> {
   private static final String CONTAINER_ID = "containerId";
   private static final String INSTANCE_ID = "instanceId";
   private static final String HOST = "host";
@@ -63,12 +63,13 @@ public final class TwillRunResourcesCodec implements JsonSerializer<TwillRunReso
     }
     json.add(LOG_LEVEL_ARGUMENTS, context.serialize(src.getLogLevelArguments(),
                                                     new TypeToken<Map<String, String>>() { }.getType()));
+
     return json;
   }
 
   @Override
   public TwillRunResources deserialize(JsonElement json, Type typeOfT,
-                                       JsonDeserializationContext context) throws JsonParseException {
+                                           JsonDeserializationContext context) throws JsonParseException {
     JsonObject jsonObj = json.getAsJsonObject();
     Map<String, String> logLevelArguments =
       context.deserialize(jsonObj.get("logLevelArguments"), new TypeToken<Map<String, String>>() { }.getType());

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRunResourcesCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRunResourcesCodec.java
@@ -71,8 +71,8 @@ public final class TwillRunResourcesCodec implements JsonSerializer<TwillRunReso
   public TwillRunResources deserialize(JsonElement json, Type typeOfT,
                                            JsonDeserializationContext context) throws JsonParseException {
     JsonObject jsonObj = json.getAsJsonObject();
-    Map<String, String> logLevelArguments =
-      context.deserialize(jsonObj.get("logLevelArguments"), new TypeToken<Map<String, String>>() { }.getType());
+    Map<String, LogEntry.Level> logLevelArguments =
+      context.deserialize(jsonObj.get("logLevelArguments"), new TypeToken<Map<String, LogEntry.Level>>() { }.getType());
     return new DefaultTwillRunResources(jsonObj.get("instanceId").getAsInt(),
                                         jsonObj.get("containerId").getAsString(),
                                         jsonObj.get("virtualCores").getAsInt(),

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationAdapter.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationAdapter.java
@@ -33,6 +33,7 @@ import org.apache.twill.api.LocalFile;
 import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.RuntimeSpecification;
 import org.apache.twill.api.TwillRunnableSpecification;
+import org.apache.twill.api.TwillRuntimeSpecification;
 import org.apache.twill.api.TwillSpecification;
 import org.apache.twill.internal.json.TwillSpecificationCodec.EventHandlerSpecificationCoder;
 import org.apache.twill.internal.json.TwillSpecificationCodec.TwillSpecificationOrderCoder;
@@ -49,17 +50,18 @@ import java.util.Map;
 /**
  *
  */
-public final class TwillSpecificationAdapter {
+public final class TwillRuntimeSpecificationAdapter {
 
   private final Gson gson;
 
-  public static TwillSpecificationAdapter create() {
-    return new TwillSpecificationAdapter();
+  public static TwillRuntimeSpecificationAdapter create() {
+    return new TwillRuntimeSpecificationAdapter();
   }
 
-  private TwillSpecificationAdapter() {
+  private TwillRuntimeSpecificationAdapter() {
     gson = new GsonBuilder()
               .serializeNulls()
+              .registerTypeAdapter(TwillRuntimeSpecification.class, new TwillRuntimeSpecificationCodec())
               .registerTypeAdapter(TwillSpecification.class, new TwillSpecificationCodec())
               .registerTypeAdapter(TwillSpecification.Order.class, new TwillSpecificationOrderCoder())
               .registerTypeAdapter(TwillSpecification.PlacementPolicy.class,
@@ -73,29 +75,29 @@ public final class TwillSpecificationAdapter {
               .create();
   }
 
-  public String toJson(TwillSpecification spec) {
-    return gson.toJson(spec, TwillSpecification.class);
+  public String toJson(TwillRuntimeSpecification spec) {
+    return gson.toJson(spec, TwillRuntimeSpecification.class);
   }
 
-  public void toJson(TwillSpecification spec, Writer writer) {
-    gson.toJson(spec, TwillSpecification.class, writer);
+  public void toJson(TwillRuntimeSpecification spec, Writer writer) {
+    gson.toJson(spec, TwillRuntimeSpecification.class, writer);
   }
 
-  public void toJson(TwillSpecification spec, File file) throws IOException {
+  public void toJson(TwillRuntimeSpecification spec, File file) throws IOException {
     try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       toJson(spec, writer);
     }
   }
 
-  public TwillSpecification fromJson(String json) {
-    return gson.fromJson(json, TwillSpecification.class);
+  public TwillRuntimeSpecification fromJson(String json) {
+    return gson.fromJson(json, TwillRuntimeSpecification.class);
   }
 
-  public TwillSpecification fromJson(Reader reader) {
-    return gson.fromJson(reader, TwillSpecification.class);
+  public TwillRuntimeSpecification fromJson(Reader reader) {
+    return gson.fromJson(reader, TwillRuntimeSpecification.class);
   }
 
-  public TwillSpecification fromJson(File file) throws IOException {
+  public TwillRuntimeSpecification fromJson(File file) throws IOException {
     try (Reader reader = Files.newReader(file, Charsets.UTF_8)) {
       return fromJson(reader);
     }

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.internal.json;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import org.apache.twill.api.TwillRuntimeSpecification;
+import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.internal.DefaultTwillRuntimeSpecification;
+
+import java.lang.reflect.Type;
+
+/**
+ *
+ */
+final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntimeSpecification>,
+                                                         JsonDeserializer<TwillRuntimeSpecification> {
+
+  private static final String FS_USER = "fsUser";
+  private static final String TWILL_APP_DIR = "twillAppDir";
+  private static final String ZK_CONNECT_STR = "zkConnectStr";
+  private static final String TWILL_RUNID = "twillRunId";
+  private static final String TWILL_APP_NAME = "twillAppName";
+  private static final String RESERVED_MEMORY = "reservedMemory";
+  private static final String RM_SCHEDULER_ADDR = "rmSchedulerAddr";
+  private static final String LOG_LEVEL = "logLevel";
+  private static final String TWILL_SPEC = "twillSpecification";
+
+  @Override
+  public JsonElement serialize(TwillRuntimeSpecification src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject json = new JsonObject();
+    json.addProperty(FS_USER, src.getFsUser());
+    json.addProperty(TWILL_APP_DIR, src.getTwillAppDir());
+    json.addProperty(ZK_CONNECT_STR, src.getZkConnectStr());
+    json.addProperty(TWILL_RUNID, src.getTwillRunId());
+    json.addProperty(TWILL_APP_NAME, src.getTwillAppName());
+    json.addProperty(RESERVED_MEMORY, src.getReservedMemory());
+    if (src.getRmSchedulerAddr() != null) {
+      json.addProperty(RM_SCHEDULER_ADDR, src.getRmSchedulerAddr());
+    }
+    if (src.getLogLevel() != null) {
+      json.addProperty(LOG_LEVEL, src.getLogLevel());
+    }
+    json.add(TWILL_SPEC, context.serialize(src.getTwillSpecification(),
+                                           new TypeToken<TwillSpecification>() { }.getType()));
+    return json;
+  }
+
+  @Override
+  public TwillRuntimeSpecification deserialize(JsonElement json, Type typeOfT,
+                                               JsonDeserializationContext context) throws JsonParseException {
+    JsonObject jsonObj = json.getAsJsonObject();
+
+    TwillSpecification twillSpecification = context.deserialize(
+      jsonObj.get(TWILL_SPEC), new TypeToken<TwillSpecification>() { }.getType());
+    return new DefaultTwillRuntimeSpecification(twillSpecification, jsonObj.get(FS_USER).getAsString(),
+                                                jsonObj.get(TWILL_APP_DIR).getAsString(),
+                                                jsonObj.get(ZK_CONNECT_STR).getAsString(),
+                                                jsonObj.get(TWILL_RUNID).getAsString(),
+                                                jsonObj.get(TWILL_APP_NAME).getAsString(),
+                                                jsonObj.get(RESERVED_MEMORY).getAsString(),
+                                                jsonObj.has(RM_SCHEDULER_ADDR) ?
+                                                  jsonObj.get(RM_SCHEDULER_ADDR).getAsString() : null,
+                                                jsonObj.has(LOG_LEVEL) ?
+                                                  jsonObj.get(LOG_LEVEL).getAsString() : null);
+  }
+}

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
@@ -34,7 +34,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
- *
+ * Codec for serializing and deserializing a {@link org.apache.twill.api.TwillRuntimeSpecification} object using json.
  */
 final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntimeSpecification>,
                                                          JsonDeserializer<TwillRuntimeSpecification> {

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
@@ -55,7 +55,7 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
     JsonObject json = new JsonObject();
     json.addProperty(TWILL_APP_DIR, src.getTwillAppDir());
     json.addProperty(ZK_CONNECT_STR, src.getZkConnectStr());
-    json.addProperty(TWILL_RUNID, src.getTwillRunId());
+    json.addProperty(TWILL_RUNID, src.getTwillAppRunId());
     json.addProperty(TWILL_APP_NAME, src.getTwillAppName());
     json.addProperty(RESERVED_MEMORY, src.getReservedMemory());
     if (src.getFsUser() != null) {

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
@@ -27,9 +27,11 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import org.apache.twill.api.TwillRuntimeSpecification;
 import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.internal.DefaultTwillRuntimeSpecification;
 
 import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  *
@@ -46,6 +48,7 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
   private static final String RM_SCHEDULER_ADDR = "rmSchedulerAddr";
   private static final String LOG_LEVEL = "logLevel";
   private static final String TWILL_SPEC = "twillSpecification";
+  private static final String LOG_LEVEL_ARGS = "logLevelArguments";
 
   @Override
   public JsonElement serialize(TwillRuntimeSpecification src, Type typeOfSrc, JsonSerializationContext context) {
@@ -66,6 +69,9 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
     }
     json.add(TWILL_SPEC, context.serialize(src.getTwillSpecification(),
                                            new TypeToken<TwillSpecification>() { }.getType()));
+    json.add(LOG_LEVEL_ARGS,
+             context.serialize(src.getLogLevelArguments(),
+                               new TypeToken<Map<String, Map<String, LogEntry.Level>>>() { }.getType()));
     return json;
   }
 
@@ -76,6 +82,9 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
 
     TwillSpecification twillSpecification = context.deserialize(
       jsonObj.get(TWILL_SPEC), new TypeToken<TwillSpecification>() { }.getType());
+    Map<String, Map<String, LogEntry.Level>> logLevelArgs =
+      context.deserialize(jsonObj.get(LOG_LEVEL_ARGS),
+                          new TypeToken<Map<String, Map<String, LogEntry.Level>>>() { }.getType());
     return new DefaultTwillRuntimeSpecification(twillSpecification,
                                                 jsonObj.has(FS_USER) ? jsonObj.get(FS_USER).getAsString() : null,
                                                 jsonObj.get(TWILL_APP_DIR).getAsString(),
@@ -86,6 +95,7 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
                                                 jsonObj.has(RM_SCHEDULER_ADDR) ?
                                                   jsonObj.get(RM_SCHEDULER_ADDR).getAsString() : null,
                                                 jsonObj.has(LOG_LEVEL) ?
-                                                  jsonObj.get(LOG_LEVEL).getAsString() : null);
+                                                  jsonObj.get(LOG_LEVEL).getAsString() : null,
+                                                logLevelArgs);
   }
 }

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
@@ -50,12 +50,14 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
   @Override
   public JsonElement serialize(TwillRuntimeSpecification src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject json = new JsonObject();
-    json.addProperty(FS_USER, src.getFsUser());
     json.addProperty(TWILL_APP_DIR, src.getTwillAppDir());
     json.addProperty(ZK_CONNECT_STR, src.getZkConnectStr());
     json.addProperty(TWILL_RUNID, src.getTwillRunId());
     json.addProperty(TWILL_APP_NAME, src.getTwillAppName());
     json.addProperty(RESERVED_MEMORY, src.getReservedMemory());
+    if (src.getFsUser() != null) {
+      json.addProperty(FS_USER, src.getFsUser());
+    }
     if (src.getRmSchedulerAddr() != null) {
       json.addProperty(RM_SCHEDULER_ADDR, src.getRmSchedulerAddr());
     }
@@ -74,7 +76,8 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
 
     TwillSpecification twillSpecification = context.deserialize(
       jsonObj.get(TWILL_SPEC), new TypeToken<TwillSpecification>() { }.getType());
-    return new DefaultTwillRuntimeSpecification(twillSpecification, jsonObj.get(FS_USER).getAsString(),
+    return new DefaultTwillRuntimeSpecification(twillSpecification,
+                                                jsonObj.has(FS_USER) ? jsonObj.get(FS_USER).getAsString() : null,
                                                 jsonObj.get(TWILL_APP_DIR).getAsString(),
                                                 jsonObj.get(ZK_CONNECT_STR).getAsString(),
                                                 jsonObj.get(TWILL_RUNID).getAsString(),

--- a/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
@@ -20,6 +20,11 @@ package org.apache.twill.internal.state;
 import org.apache.twill.api.Command;
 
 import com.google.common.base.Preconditions;
+import org.apache.twill.api.logging.LogEntry;
+import org.apache.twill.internal.Constants;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Collection of predefined system messages.
@@ -29,6 +34,7 @@ public final class SystemMessages {
   public static final Command STOP_COMMAND = Command.Builder.of("stop").build();
   public static final Message SECURE_STORE_UPDATED = new SimpleMessage(
     Message.Type.SYSTEM, Message.Scope.APPLICATION, null, Command.Builder.of("secureStoreUpdated").build());
+  public static final String ALL_RUNNABLES = "ALL";
 
   public static Message stopApplication() {
     return new SimpleMessage(Message.Type.SYSTEM, Message.Scope.APPLICATION, null, STOP_COMMAND);
@@ -66,6 +72,23 @@ public final class SystemMessages {
   public static Message updateRunnablesInstances(Command updateCommand) {
     Preconditions.checkNotNull(updateCommand);
     return new SimpleMessage(Message.Type.SYSTEM, Message.Scope.RUNNABLES, null, updateCommand);
+  }
+
+  public static Message setLogLevel(Map<String, LogEntry.Level> logLevelArguments) {
+    return setLogLevel(ALL_RUNNABLES, logLevelArguments);
+  }
+
+  public static Message setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelArguments) {
+    Preconditions.checkNotNull(runnableName);
+    Preconditions.checkNotNull(logLevelArguments);
+    Map<String, String> options = new LinkedHashMap<>();
+    for (Map.Entry<String, LogEntry.Level> entry : logLevelArguments.entrySet()) {
+      options.put(entry.getKey(), entry.getValue().name());
+    }
+    return new SimpleMessage(Message.Type.SYSTEM,
+                             runnableName.equals(ALL_RUNNABLES) ? Message.Scope.ALL_RUNNABLE : Message.Scope.RUNNABLE,
+                             runnableName, Command.Builder.of(Constants.SystemMessages.LOG_LEVEL)
+                               .addOptions(options).build());
   }
 
   private SystemMessages() {

--- a/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
@@ -22,6 +22,7 @@ import org.apache.twill.api.Command;
 import com.google.common.base.Preconditions;
 import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.internal.Constants;
+import org.apache.twill.internal.utils.LogLevelUtil;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -81,10 +82,7 @@ public final class SystemMessages {
   public static Message setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelArguments) {
     Preconditions.checkNotNull(runnableName);
     Preconditions.checkNotNull(logLevelArguments);
-    Map<String, String> options = new LinkedHashMap<>();
-    for (Map.Entry<String, LogEntry.Level> entry : logLevelArguments.entrySet()) {
-      options.put(entry.getKey(), entry.getValue().name());
-    }
+    Map<String, String> options = LogLevelUtil.convertLogLevelArgs(logLevelArguments);
     return new SimpleMessage(Message.Type.SYSTEM,
                              runnableName.equals(ALL_RUNNABLES) ? Message.Scope.ALL_RUNNABLE : Message.Scope.RUNNABLE,
                              runnableName, Command.Builder.of(Constants.SystemMessages.LOG_LEVEL)

--- a/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
@@ -81,7 +81,7 @@ public final class SystemMessages {
   public static Message setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelArguments) {
     Preconditions.checkNotNull(runnableName);
     Preconditions.checkNotNull(logLevelArguments);
-    Map<String, String> options = LogLevelUtil.convertLogLevelArgs(logLevelArguments);
+    Map<String, String> options = LogLevelUtil.convertLogLevelValuesToString(logLevelArguments);
     return new SimpleMessage(Message.Type.SYSTEM,
                              runnableName.equals(ALL_RUNNABLES) ? Message.Scope.ALL_RUNNABLE : Message.Scope.RUNNABLE,
                              runnableName, Command.Builder.of(Constants.SystemMessages.LOG_LEVEL)

--- a/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
@@ -24,7 +24,6 @@ import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.utils.LogLevelUtil;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**

--- a/twill-core/src/main/java/org/apache/twill/internal/utils/LogLevelUtil.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/utils/LogLevelUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.internal.utils;
+
+import org.apache.twill.api.logging.LogEntry;
+import org.apache.twill.internal.Constants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ */
+public final class LogLevelUtil {
+
+  public static Map<String, String> convertLogLevelArgs(Map<String, LogEntry.Level> logLevelArguments) {
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<String, LogEntry.Level> entry : logLevelArguments.entrySet()) {
+      result.put(entry.getKey(), entry.getValue().toString());
+    }
+    return result;
+  }
+
+  public static Map<String, String> getLogLevelForRunnable(String runnableName,
+                                                           Map<String, Map<String, LogEntry.Level>> logLevelArguments) {
+    Map<String, LogEntry.Level> logAppArguments = logLevelArguments.get(Constants.SystemMessages.LOG_ALL_RUNNABLES);
+    Map<String, LogEntry.Level> logRunnableArguments = logLevelArguments.get(runnableName);
+    Map<String, LogEntry.Level> result = logAppArguments;
+    if (logAppArguments == null && logRunnableArguments == null) {
+      return new HashMap<>();
+    } else if (logAppArguments == null) {
+      result = logRunnableArguments;
+    } else if (logRunnableArguments != null) {
+      result.putAll(logRunnableArguments);
+    }
+    return convertLogLevelArgs(result);
+  }
+
+  private LogLevelUtil() {
+  }
+}

--- a/twill-core/src/main/java/org/apache/twill/internal/utils/LogLevelUtil.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/utils/LogLevelUtil.java
@@ -29,9 +29,9 @@ import java.util.Map;
 public final class LogLevelUtil {
 
   /**
-   * Convert the log level argument type.
+   * Convert the log level argument value type to string.
    */
-  public static Map<String, String> convertLogLevelArgs(Map<String, LogEntry.Level> logLevelArguments) {
+  public static Map<String, String> convertLogLevelValuesToString(Map<String, LogEntry.Level> logLevelArguments) {
     Map<String, String> result = new HashMap<>();
     for (Map.Entry<String, LogEntry.Level> entry : logLevelArguments.entrySet()) {
       result.put(entry.getKey(), entry.getValue().toString());
@@ -40,14 +40,26 @@ public final class LogLevelUtil {
   }
 
   /**
+   * Convert the log level argument type to LogEntry.Level
+   */
+  public static Map<String, LogEntry.Level> convertLogLevelValuesToLogEntry(Map<String, String> logLevelArguments) {
+    Map<String, LogEntry.Level> result = new HashMap<>();
+    for (Map.Entry<String, String> entry : logLevelArguments.entrySet()) {
+      result.put(entry.getKey(), LogEntry.Level.valueOf(entry.getValue()));
+    }
+    return result;
+  }
+
+
+  /**
    * Get the log level arguments for a twill runnable.
    *
    * @param runnableName name of the runnable.
    * @param logLevelArguments the arguments for all runnables.
    * @return the map of the log level arguments for the runnable, empty if there is no argument.
    */
-  public static Map<String, String> getLogLevelForRunnable(String runnableName,
-                                                           Map<String, Map<String, LogEntry.Level>> logLevelArguments) {
+  public static Map<String, LogEntry.Level> getLogLevelForRunnable(
+    String runnableName, Map<String, Map<String, LogEntry.Level>> logLevelArguments) {
     if (logLevelArguments.isEmpty()) {
       return new HashMap<>();
     }
@@ -61,7 +73,7 @@ public final class LogLevelUtil {
     } else if (logRunnableArguments != null) {
       result.putAll(logRunnableArguments);
     }
-    return convertLogLevelArgs(result);
+    return result;
   }
 
   private LogLevelUtil() {

--- a/twill-core/src/main/java/org/apache/twill/internal/utils/LogLevelUtil.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/utils/LogLevelUtil.java
@@ -24,10 +24,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- *
+ * Collections of helper functions for log level change.
  */
 public final class LogLevelUtil {
 
+  /**
+   * Convert the log level argument type.
+   */
   public static Map<String, String> convertLogLevelArgs(Map<String, LogEntry.Level> logLevelArguments) {
     Map<String, String> result = new HashMap<>();
     for (Map.Entry<String, LogEntry.Level> entry : logLevelArguments.entrySet()) {
@@ -36,8 +39,18 @@ public final class LogLevelUtil {
     return result;
   }
 
+  /**
+   * Get the log level arguments for a twill runnable.
+   *
+   * @param runnableName name of the runnable.
+   * @param logLevelArguments the arguments for all runnables.
+   * @return the map of the log level arguments for the runnable, empty if there is no argument.
+   */
   public static Map<String, String> getLogLevelForRunnable(String runnableName,
                                                            Map<String, Map<String, LogEntry.Level>> logLevelArguments) {
+    if (logLevelArguments.isEmpty()) {
+      return new HashMap<>();
+    }
     Map<String, LogEntry.Level> logAppArguments = logLevelArguments.get(Constants.SystemMessages.LOG_ALL_RUNNABLES);
     Map<String, LogEntry.Level> logRunnableArguments = logLevelArguments.get(runnableName);
     Map<String, LogEntry.Level> result = logAppArguments;

--- a/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
@@ -129,11 +129,11 @@ public abstract class ServiceMain {
   protected abstract String getRunnableName();
 
   /**
-   * Returns the {@link Location} for the application based on the env {@link EnvKeys#TWILL_APP_DIR}.
+   * Returns the {@link Location} for the application based on the app directory.
    */
-  protected static Location createAppLocation(final Configuration conf) {
+  protected static Location createAppLocation(final Configuration conf, String fsUser, String appDirectory) {
     // Note: It's a little bit hacky based on the uri schema to create the LocationFactory, refactor it later.
-    final URI appDir = URI.create(System.getenv(EnvKeys.TWILL_APP_DIR));
+    final URI appDir = URI.create(appDirectory);
 
     try {
       if ("file".equals(appDir.getScheme())) {
@@ -145,9 +145,8 @@ public abstract class ServiceMain {
       if (UserGroupInformation.isSecurityEnabled()) {
         ugi = UserGroupInformation.getCurrentUser();
       } else {
-        String fsUser = System.getenv(EnvKeys.TWILL_FS_USER);
         if (fsUser == null) {
-          throw new IllegalStateException("Missing environment variable " + EnvKeys.TWILL_FS_USER);
+          throw new IllegalStateException("Missing environment variable " + Constants.Environments.TWILL_FS_USER);
         }
         ugi = UserGroupInformation.createRemoteUser(fsUser);
       }

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
@@ -23,10 +23,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
+import org.apache.twill.api.TwillRuntimeSpecification;
 import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.EnvKeys;
 import org.apache.twill.internal.RunIds;
 import org.apache.twill.internal.ServiceMain;
+import org.apache.twill.internal.json.TwillRuntimeSpecificationAdapter;
 import org.apache.twill.internal.kafka.EmbeddedKafkaServer;
 import org.apache.twill.internal.logging.Loggings;
 import org.apache.twill.internal.yarn.VersionDetectYarnAMClientFactory;
@@ -64,17 +66,20 @@ public final class ApplicationMasterMain extends ServiceMain {
    * Starts the application master.
    */
   public static void main(String[] args) throws Exception {
-    String zkConnect = System.getenv(EnvKeys.TWILL_ZK_CONNECT);
     File twillSpec = new File(Constants.Files.TWILL_SPEC);
-    RunId runId = RunIds.fromString(System.getenv(EnvKeys.TWILL_RUN_ID));
+    TwillRuntimeSpecification twillRuntimeSpec = TwillRuntimeSpecificationAdapter.create().fromJson(twillSpec);
+    String zkConnect = twillRuntimeSpec.getZkConnectStr();
+    RunId runId = RunIds.fromString(twillRuntimeSpec.getTwillRunId());
 
-    ZKClientService zkClientService = createZKClient(zkConnect, System.getenv(EnvKeys.TWILL_APP_NAME));
+    ZKClientService zkClientService = createZKClient(zkConnect, twillRuntimeSpec.getTwillAppName());
     Configuration conf = new YarnConfiguration(new HdfsConfiguration(new Configuration()));
-    setRMSchedulerAddress(conf);
+    setRMSchedulerAddress(conf, twillRuntimeSpec.getRmSchedulerAddr());
 
     final YarnAMClient amClient = new VersionDetectYarnAMClientFactory(conf).create();
     ApplicationMasterService service = new ApplicationMasterService(runId, zkClientService,
-                                                                    twillSpec, amClient, createAppLocation(conf));
+                                                                    twillSpec, amClient, createAppLocation(
+                                                                      conf, twillRuntimeSpec.getFsUser(),
+                                                                      twillRuntimeSpec.getTwillAppDir()));
     TrackerService trackerService = new TrackerService(service);
 
     new ApplicationMasterMain(service.getKafkaZKConnect())
@@ -90,8 +95,7 @@ public final class ApplicationMasterMain extends ServiceMain {
   /**
    * Optionally sets the RM scheduler address based on the environment variable if it is not set in the cluster config.
    */
-  private static void setRMSchedulerAddress(Configuration conf) {
-    String schedulerAddress = System.getenv(EnvKeys.YARN_RM_SCHEDULER_ADDRESS);
+  private static void setRMSchedulerAddress(Configuration conf, String schedulerAddress) {
     if (schedulerAddress == null) {
       return;
     }
@@ -122,7 +126,6 @@ public final class ApplicationMasterMain extends ServiceMain {
   protected String getRunnableName() {
     return System.getenv(EnvKeys.TWILL_RUNNABLE_NAME);
   }
-
 
   /**
    * A service wrapper for starting/stopping {@link EmbeddedKafkaServer} and make sure the ZK path for

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
@@ -69,7 +69,7 @@ public final class ApplicationMasterMain extends ServiceMain {
     File twillSpec = new File(Constants.Files.TWILL_SPEC);
     TwillRuntimeSpecification twillRuntimeSpec = TwillRuntimeSpecificationAdapter.create().fromJson(twillSpec);
     String zkConnect = twillRuntimeSpec.getZkConnectStr();
-    RunId runId = RunIds.fromString(twillRuntimeSpec.getTwillRunId());
+    RunId runId = RunIds.fromString(twillRuntimeSpec.getTwillAppRunId());
 
     ZKClientService zkClientService = createZKClient(zkConnect, twillRuntimeSpec.getTwillAppName());
     Configuration conf = new YarnConfiguration(new HdfsConfiguration(new Configuration()));
@@ -77,7 +77,7 @@ public final class ApplicationMasterMain extends ServiceMain {
 
     final YarnAMClient amClient = new VersionDetectYarnAMClientFactory(conf).create();
     ApplicationMasterService service = new ApplicationMasterService(runId, zkClientService,
-                                                                    twillSpec, amClient, createAppLocation(
+                                                                    twillRuntimeSpec, amClient, createAppLocation(
                                                                       conf, twillRuntimeSpec.getFsUser(),
                                                                       twillRuntimeSpec.getTwillAppDir()));
     TrackerService trackerService = new TrackerService(service);

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
@@ -133,12 +133,12 @@ public final class ApplicationMasterService extends AbstractYarnTwillService imp
   private Queue<RunnableContainerRequest> runnableContainerRequests;
   private ExecutorService instanceChangeExecutor;
 
-  public ApplicationMasterService(RunId runId, ZKClient zkClient, File twillSpecFile,
+  public ApplicationMasterService(RunId runId, ZKClient zkClient, TwillRuntimeSpecification twillRuntimeSpec,
                                   YarnAMClient amClient, Location applicationLocation) throws Exception {
     super(zkClient, runId, applicationLocation);
 
     this.runId = runId;
-    this.twillRuntimeSpec = TwillRuntimeSpecificationAdapter.create().fromJson(twillSpecFile);
+    this.twillRuntimeSpec = twillRuntimeSpec;
     this.zkClient = zkClient;
     this.applicationLocation = applicationLocation;
     this.amClient = amClient;

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
@@ -968,6 +968,11 @@ public final class ApplicationMasterService extends AbstractYarnTwillService imp
     };
   }
 
+  /**
+   * Attempt to change the log level from a runnable or all runnables.
+   *
+   * @return {@code true} if the message requests changing log levels and {@code false} otherwise.
+   */
   private boolean handleLogLevelChange(final Message message, final Runnable completion) {
     Message.Scope scope = message.getScope();
     if (message.getType() != Message.Type.SYSTEM ||

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
@@ -212,7 +212,7 @@ public final class ApplicationMasterService extends AbstractYarnTwillService imp
       Integer.parseInt(System.getenv(EnvKeys.YARN_CONTAINER_MEMORY_MB)),
       appMasterHost, null, null);
     String appId = appMasterContainerId.getApplicationAttemptId().getApplicationId().toString();
-    return new RunningContainers(appId, appMasterResources, zkClient);
+    return new RunningContainers(appId, appMasterResources, zkClient, twillRuntimeSpec.getLogLevelArguments());
   }
 
   private ExpectedContainers initExpectedContainers(TwillSpecification twillSpec) {

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunningContainers.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunningContainers.java
@@ -34,10 +34,12 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 import org.apache.hadoop.yarn.api.records.ContainerState;
+import org.apache.twill.api.Command;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillRunResources;
 import org.apache.twill.api.logging.LogEntry;
+import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.ContainerExitCodes;
 import org.apache.twill.internal.ContainerInfo;
 import org.apache.twill.internal.ContainerLiveNodeData;
@@ -474,6 +476,11 @@ final class RunningContainers {
     Futures.addCallback(controller.sendMessage(message), new FutureCallback<Message>() {
       @Override
       public void onSuccess(Message result) {
+        //update log level information
+        Command command = message.getCommand();
+        if (Constants.SystemMessages.LOG_LEVEL.equals(command.getCommand())) {
+          resourceReport.updateLogLevel(runnableName, command.getOptions());
+        }
         if (count.decrementAndGet() == 0) {
           completion.run();
         }

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunningContainers.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunningContainers.java
@@ -126,7 +126,7 @@ final class RunningContainers {
   /**
    * Start a container for a runnable.
    */
-  void start(String runnableName, ContainerInfo containerInfo, TwillContainerLauncher launcher) {
+  void start(String runnableName, ContainerInfo containerInfo, TwillContainerLauncher launcher, String logLevel) {
     containerLock.lock();
     try {
       int instanceId = getStartInstanceId(runnableName);
@@ -140,7 +140,7 @@ final class RunningContainers {
                                                                  containerInfo.getMemoryMB(),
                                                                  containerInfo.getHost().getHostName(),
                                                                  controller,
-                                                                 System.getenv(EnvKeys.TWILL_APP_LOG_LEVEL));
+                                                                 logLevel);
       resourceReport.addRunResources(runnableName, resources);
       containerStats.put(runnableName, containerInfo);
 

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunningContainers.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/RunningContainers.java
@@ -591,19 +591,6 @@ final class RunningContainers {
     return false;
   }
 
-  private Map<String, LogEntry.Level> getLogLevelArguments(String runnableName) {
-    Map<String, LogEntry.Level> logAppArguments = logLevelArguments.get(Constants.SystemMessages.LOG_ALL_RUNNABLES);
-    Map<String, LogEntry.Level> logRunnableArguments = logLevelArguments.get(runnableName);
-    if (logAppArguments == null && logRunnableArguments == null) {
-      return new HashMap<>();
-    } else if (logAppArguments == null) {
-      logAppArguments = logRunnableArguments;
-    } else if (logRunnableArguments != null) {
-      logAppArguments.putAll(logRunnableArguments);
-    }
-    return logAppArguments;
-  }
-
   /**
    * A helper class that overrides the debug port of the resources with the live info from the container controller.
    */

--- a/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillRunnableSpecification;
+import org.apache.twill.api.TwillRuntimeSpecification;
 import org.apache.twill.api.TwillSpecification;
 import org.apache.twill.discovery.ZKDiscoveryService;
 import org.apache.twill.internal.Arguments;
@@ -41,7 +42,7 @@ import org.apache.twill.internal.EnvKeys;
 import org.apache.twill.internal.RunIds;
 import org.apache.twill.internal.ServiceMain;
 import org.apache.twill.internal.json.ArgumentsCodec;
-import org.apache.twill.internal.json.TwillSpecificationAdapter;
+import org.apache.twill.internal.json.TwillRuntimeSpecificationAdapter;
 import org.apache.twill.internal.logging.Loggings;
 import org.apache.twill.zookeeper.ZKClient;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -83,9 +84,10 @@ public final class TwillContainerMain extends ServiceMain {
 
     ZKClient appRunZkClient = getAppRunZKClient(zkClientService, appRunId);
 
-    TwillSpecification twillSpec = loadTwillSpec(twillSpecFile);
+    TwillRuntimeSpecification twillRuntimeSpec = loadTwillSpec(twillSpecFile);
     
-    TwillRunnableSpecification runnableSpec = twillSpec.getRunnables().get(runnableName).getRunnableSpecification();
+    TwillRunnableSpecification runnableSpec =
+      twillRuntimeSpec.getTwillSpecification().getRunnables().get(runnableName).getRunnableSpecification();
     ContainerInfo containerInfo = new EnvContainerInfo();
     Arguments arguments = decodeArgs();
     BasicTwillContext context = new BasicTwillContext(
@@ -156,9 +158,9 @@ public final class TwillContainerMain extends ServiceMain {
     return classLoader;
   }
 
-  private static TwillSpecification loadTwillSpec(File specFile) throws IOException {
+  private static TwillRuntimeSpecification loadTwillSpec(File specFile) throws IOException {
     try (Reader reader = Files.newReader(specFile, Charsets.UTF_8)) {
-      return TwillSpecificationAdapter.create().fromJson(reader);
+      return TwillRuntimeSpecificationAdapter.create().fromJson(reader);
     }
   }
 

--- a/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillRunnableSpecification;
 import org.apache.twill.api.TwillRuntimeSpecification;
+import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.discovery.ZKDiscoveryService;
 import org.apache.twill.internal.Arguments;
 import org.apache.twill.internal.BasicTwillContext;
@@ -79,7 +80,7 @@ public final class TwillContainerMain extends ServiceMain {
     File twillSpecFile = new File(Constants.Files.TWILL_SPEC);
     TwillRuntimeSpecification twillRuntimeSpec = loadTwillSpec(twillSpecFile);
     String zkConnectStr = twillRuntimeSpec.getZkConnectStr();
-    RunId appRunId = RunIds.fromString(twillRuntimeSpec.getTwillRunId());
+    RunId appRunId = RunIds.fromString(twillRuntimeSpec.getTwillAppRunId());
     RunId runId = RunIds.fromString(System.getenv(EnvKeys.TWILL_RUN_ID));
     String runnableName = System.getenv(EnvKeys.TWILL_RUNNABLE_NAME);
     int instanceId = Integer.parseInt(System.getenv(EnvKeys.TWILL_INSTANCE_ID));
@@ -104,7 +105,7 @@ public final class TwillContainerMain extends ServiceMain {
 
     ZKClient containerZKClient = getContainerZKClient(zkClientService, appRunId, runnableName);
     Configuration conf = new YarnConfiguration(new HdfsConfiguration(new Configuration()));
-    Map<String, String> logLevelArguments = LogLevelUtil.getLogLevelForRunnable(
+    Map<String, LogEntry.Level> logLevelArguments = LogLevelUtil.getLogLevelForRunnable(
       System.getenv(EnvKeys.TWILL_RUNNABLE_NAME), twillRuntimeSpec.getLogLevelArguments());
     TwillContainerService service = new TwillContainerService(context, containerInfo, containerZKClient,
                                                               runId, runnableSpec, getClassLoader(),

--- a/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillRunnableSpecification;
 import org.apache.twill.api.TwillRuntimeSpecification;
-import org.apache.twill.api.logging.LogEntry;
 import org.apache.twill.discovery.ZKDiscoveryService;
 import org.apache.twill.internal.Arguments;
 import org.apache.twill.internal.BasicTwillContext;
@@ -55,7 +54,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -174,19 +172,6 @@ public final class TwillContainerMain extends ServiceMain {
 
   private static Arguments decodeArgs() throws IOException {
     return ArgumentsCodec.decode(Files.newReaderSupplier(new File(Constants.Files.ARGUMENTS), Charsets.UTF_8));
-  }
-
-  private static Map<String, LogEntry.Level> getLogLevelArguments(Map<String, Map<String, LogEntry.Level>> allLogArgs) {
-    Map<String, LogEntry.Level> logAppArguments = allLogArgs.get(Constants.SystemMessages.LOG_ALL_RUNNABLES);
-    Map<String, LogEntry.Level> logRunnableArguments = allLogArgs.get(System.getenv(EnvKeys.TWILL_RUNNABLE_NAME));
-    if (logAppArguments == null && logRunnableArguments == null) {
-      return new HashMap<>();
-    } else if (logAppArguments == null) {
-      logAppArguments = logRunnableArguments;
-    } else if (logRunnableArguments != null) {
-      logAppArguments.putAll(logRunnableArguments);
-    }
-    return logAppArguments;
   }
 
   @Override

--- a/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerService.java
@@ -17,6 +17,8 @@
  */
 package org.apache.twill.internal.container;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -28,15 +30,18 @@ import org.apache.twill.api.TwillRunnableSpecification;
 import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.internal.BasicTwillContext;
+import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.ContainerInfo;
 import org.apache.twill.internal.ContainerLiveNodeData;
 import org.apache.twill.internal.state.Message;
 import org.apache.twill.internal.utils.Instances;
 import org.apache.twill.internal.yarn.AbstractYarnTwillService;
 import org.apache.twill.zookeeper.ZKClient;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -96,6 +101,10 @@ public final class TwillContainerService extends AbstractYarnTwillService {
       context.setInstanceCount(Integer.parseInt(command.getOptions().get("count")));
     }
 
+    if (message.getType() == Message.Type.SYSTEM && Constants.SystemMessages.LOG_LEVEL.equals(command.getCommand())) {
+      return setLogLevel(messageId, command);
+    }
+
     commandExecutor.execute(new Runnable() {
 
       @Override
@@ -151,5 +160,25 @@ public final class TwillContainerService extends AbstractYarnTwillService {
     } catch (Throwable t) {
       LOG.error("Exception when stopping runnable.", t);
     }
+  }
+
+  private ListenableFuture<String> setLogLevel(String messageId, Command command) {
+    ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+    if (!(loggerFactory instanceof LoggerContext)) {
+      String errorMsg = "LoggerFactory is not a logback LoggerContext, cannot change log level";
+      LOG.error(errorMsg);
+      return Futures.immediateFailedFuture(new Exception(errorMsg));
+    }
+
+    Map<String, String> logLevelArguments = command.getOptions();
+    LoggerContext loggerContext = (LoggerContext) loggerFactory;
+    for (Map.Entry<String, String> entry : logLevelArguments.entrySet()) {
+      String loggerName = entry.getKey();
+      String logLevel = entry.getValue();
+      ch.qos.logback.classic.Logger logger = loggerContext.getLogger(loggerName);
+      LOG.info("Log level of {} changed from {} to {}", loggerName, logger.getLevel(), logLevel);
+      logger.setLevel(Level.toLevel(logLevel));
+    }
+    return Futures.immediateFuture(messageId);
   }
 }

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
@@ -303,6 +303,16 @@ final class YarnTwillPreparer implements TwillPreparer {
   }
 
   @Override
+  public TwillPreparer setLogLevel(Map<String, LogEntry.Level> logLevelAppArgs) {
+    return null;
+  }
+
+  @Override
+  public TwillPreparer setLogLevel(String runnableName, Map<String, LogEntry.Level> logLevelRunnableArgs) {
+    return null;
+  }
+
+  @Override
   public TwillController start() {
     try {
       final ProcessLauncher<ApplicationMasterInfo> launcher = yarnAppClient.createLauncher(twillSpec, schedulerQueue);

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
@@ -359,9 +359,6 @@ final class YarnTwillPreparer implements TwillPreparer {
           //     appMaster.jar
           //     org.apache.twill.internal.appmaster.ApplicationMasterMain
           //     false
-          //  .put(EnvKeys.TWILL_FS_USER, fsUser)
-         //   .put(EnvKeys.TWILL_RUN_ID, runId.getId())
-         //   .put(EnvKeys.TWILL_APP_NAME, twillSpec.getName());
 
           LOG.debug("Log level is set to {} for the Twill application.", logLevel);
 

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.twill.yarn;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.apache.twill.api.AbstractTwillRunnable;
+import org.apache.twill.api.ResourceReport;
+import org.apache.twill.api.TwillApplication;
+import org.apache.twill.api.TwillController;
+import org.apache.twill.api.TwillRunResources;
+import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.api.logging.LogEntry;
+import org.apache.twill.api.logging.PrinterLogHandler;
+import org.apache.twill.common.Threads;
+import org.apache.twill.internal.Constants;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test changing log level for a twill runnable.
+ */
+public class LogLevelChangeTestRun extends BaseYarnTest {
+  public static final Logger LOG = LoggerFactory.getLogger(LogLevelChangeTestRun.class);
+
+  /**
+   * Twill runnable.
+   */
+  public static final class LogLevelTestRunnable extends AbstractTwillRunnable {
+    private volatile Thread runThread;
+
+    @Override
+    public void run() {
+      this.runThread = Thread.currentThread();
+      while (!Thread.interrupted()) {
+        try {
+          TimeUnit.MILLISECONDS.sleep(500);
+        } catch (InterruptedException e) {
+          break;
+        }
+      }
+    }
+
+    @Override
+    public void stop() {
+      if (runThread != null) {
+        runThread.interrupt();
+      }
+    }
+  }
+
+  /**
+   * .
+   */
+  public static final class LogLevelTestSecondRunnable extends AbstractTwillRunnable {
+    private volatile Thread runThread;
+
+    @Override
+    public void run() {
+      this.runThread = Thread.currentThread();
+      while (!Thread.interrupted()) {
+        try {
+          TimeUnit.MILLISECONDS.sleep(500);
+        } catch (InterruptedException e) {
+          break;
+        }
+      }
+    }
+
+    @Override
+    public void stop() {
+      if (runThread != null) {
+        runThread.interrupt();
+      }
+    }
+  }
+
+  /**
+   * A test TwillApplication to test setting log level to DEBUG.
+   */
+  public static final class LogLevelTestApplication implements TwillApplication {
+
+    @Override
+    public TwillSpecification configure() {
+      return TwillSpecification.Builder.with()
+        .setName("LogLevelChangeTest")
+        .withRunnable()
+        .add(LogLevelTestRunnable.class.getSimpleName(), new LogLevelTestRunnable()).noLocalFiles()
+        .add(LogLevelTestSecondRunnable.class.getSimpleName(), new LogLevelTestSecondRunnable()).noLocalFiles()
+        .anyOrder()
+        .build();
+    }
+
+  }
+
+  @Test
+  public void testDebugLogLevel()throws Exception {
+    YarnTwillRunnerService runner = getTwillRunner();
+    runner.start();
+
+    // Set log level to ERROR
+    TwillController controller = runner.prepare(new LogLevelTestApplication())
+      .setLogLevel(LogEntry.Level.ERROR)
+      .addLogHandler(new PrinterLogHandler(new PrintWriter(System.out)))
+      .start();
+
+    // Lets wait until the service is running
+    final CountDownLatch running = new CountDownLatch(1);
+    controller.onRunning(new Runnable() {
+      @Override
+      public void run() {
+        running.countDown();
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+    Assert.assertTrue(running.await(200, TimeUnit.SECONDS));
+
+    // assert that log level is ERROR
+    waitForLogLevel(controller, LogLevelTestRunnable.class.getSimpleName(),
+                    200L, TimeUnit.SECONDS, LogEntry.Level.ERROR, ImmutableMap.<String, String>of());
+
+    waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(),
+                    200L, TimeUnit.SECONDS, LogEntry.Level.ERROR, ImmutableMap.<String, String>of());
+
+    // change the log level to INFO
+    controller.setLogLevel(LogEntry.Level.INFO).get();
+
+    // assert log level has changed to INFO
+    waitForLogLevel(controller, LogLevelTestRunnable.class.getSimpleName(),
+                    200L, TimeUnit.SECONDS, LogEntry.Level.INFO, ImmutableMap.of("ROOT", "INFO"));
+
+    waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(),
+                    200L, TimeUnit.SECONDS, LogEntry.Level.INFO, ImmutableMap.of("ROOT", "INFO"));
+
+    // change the log level of LogLevelTestRunnable to WARN,
+    // change the log level of LogLevelTestSecondRunnable to TRACE
+    Map<String, LogEntry.Level> logLevelFirstRunnable = ImmutableMap.of(Logger.ROOT_LOGGER_NAME, LogEntry.Level.WARN);
+    Map<String, LogEntry.Level> logLevelSecondRunnable = ImmutableMap.of(Logger.ROOT_LOGGER_NAME, LogEntry.Level.TRACE);
+    controller.setLogLevel(LogLevelTestRunnable.class.getSimpleName(), logLevelFirstRunnable).get();
+    controller.setLogLevel(LogLevelTestSecondRunnable.class.getSimpleName(), logLevelSecondRunnable).get();
+
+    waitForLogLevel(controller, LogLevelTestRunnable.class.getSimpleName(),
+                    200L, TimeUnit.SECONDS, LogEntry.Level.WARN, ImmutableMap.of("ROOT", "WARN"));
+    waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(),
+                    200L, TimeUnit.SECONDS, LogEntry.Level.TRACE, ImmutableMap.of("ROOT", "TRACE"));
+
+    // stop
+    controller.terminate().get(120, TimeUnit.SECONDS);
+
+    // Sleep a bit for full cleanup
+    TimeUnit.SECONDS.sleep(2);
+  }
+
+  // Need helper method here to wait for getting resource report because {@link TwillController#getResourceReport()}
+  // could return null if the application has not fully started.
+  private void waitForLogLevel(TwillController controller, String runnable, long timeout,
+                               TimeUnit timeoutUnit, LogEntry.Level expected,
+                               Map<String, String> expectedArgs) throws InterruptedException {
+
+    Stopwatch stopwatch = new Stopwatch();
+    stopwatch.start();
+    LogEntry.Level actual = null;
+    Map<String, String> actualArgs = null;
+    boolean stopped = false;
+    do {
+      ResourceReport report = controller.getResourceReport();
+      if (report == null || report.getRunnableResources(runnable) == null) {
+        continue;
+      }
+      for (TwillRunResources resources : report.getRunnableResources(runnable)) {
+        actual = resources.getRootLogLevel();
+        actualArgs = resources.getLogLevelArguments();
+        LOG.info("Yaojie - runnable: {} {} == {}, args = {}", runnable, actual, expected, actualArgs);
+        if (actual != null && actual.equals(expected) && actualArgs != null) {
+          stopped = true;
+          break;
+        }
+      }
+      TimeUnit.MILLISECONDS.sleep(100);
+    } while (!stopped && stopwatch.elapsedTime(timeoutUnit) < timeout);
+
+    Assert.assertEquals(expected, actual);
+    Assert.assertEquals(expectedArgs, actualArgs);
+  }
+}

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
@@ -170,20 +170,20 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
 
     // assert that log level is DEBUG
     waitForLogLevel(controller, LogLevelTestRunnable.class.getSimpleName(),
-                    20L, TimeUnit.SECONDS, LogEntry.Level.DEBUG, ImmutableMap.<String, String>of());
+                    20L, TimeUnit.SECONDS, LogEntry.Level.DEBUG, ImmutableMap.<String, LogEntry.Level>of());
 
     waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(),
-                    20L, TimeUnit.SECONDS, LogEntry.Level.DEBUG, ImmutableMap.<String, String>of());
+                    20L, TimeUnit.SECONDS, LogEntry.Level.DEBUG, ImmutableMap.<String, LogEntry.Level>of());
 
     // change the log level to INFO
     controller.setLogLevel(LogEntry.Level.INFO).get();
 
     // assert log level has changed to INFO
     waitForLogLevel(controller, LogLevelTestRunnable.class.getSimpleName(),
-                    20L, TimeUnit.SECONDS, LogEntry.Level.INFO, ImmutableMap.of("ROOT", "INFO"));
+                    20L, TimeUnit.SECONDS, LogEntry.Level.INFO, ImmutableMap.of("ROOT", LogEntry.Level.INFO));
 
     waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(),
-                    20L, TimeUnit.SECONDS, LogEntry.Level.INFO, ImmutableMap.of("ROOT", "INFO"));
+                    20L, TimeUnit.SECONDS, LogEntry.Level.INFO, ImmutableMap.of("ROOT", LogEntry.Level.INFO));
 
     // change the log level of LogLevelTestRunnable to WARN,
     // change the log level of LogLevelTestSecondRunnable to TRACE
@@ -193,9 +193,9 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
     controller.setLogLevel(LogLevelTestSecondRunnable.class.getSimpleName(), logLevelSecondRunnable).get();
 
     waitForLogLevel(controller, LogLevelTestRunnable.class.getSimpleName(),
-                    20L, TimeUnit.SECONDS, LogEntry.Level.WARN, ImmutableMap.of("ROOT", "WARN"));
+                    20L, TimeUnit.SECONDS, LogEntry.Level.WARN, ImmutableMap.of("ROOT", LogEntry.Level.WARN));
     waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(),
-                    20L, TimeUnit.SECONDS, LogEntry.Level.TRACE, ImmutableMap.of("ROOT", "TRACE"));
+                    20L, TimeUnit.SECONDS, LogEntry.Level.TRACE, ImmutableMap.of("ROOT", LogEntry.Level.TRACE));
 
     // stop
     controller.terminate().get(120, TimeUnit.SECONDS);
@@ -208,12 +208,12 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
   // could return null if the application has not fully started.
   private void waitForLogLevel(TwillController controller, String runnable, long timeout,
                                TimeUnit timeoutUnit, LogEntry.Level expected,
-                               Map<String, String> expectedArgs) throws InterruptedException {
+                               Map<String, LogEntry.Level> expectedArgs) throws InterruptedException {
 
     Stopwatch stopwatch = new Stopwatch();
     stopwatch.start();
     LogEntry.Level actual = null;
-    Map<String, String> actualArgs = null;
+    Map<String, LogEntry.Level> actualArgs = null;
     boolean stopped = false;
     do {
       ResourceReport report = controller.getResourceReport();

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
@@ -80,7 +80,7 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
   }
 
   /**
-   * .
+   * Second runnable.
    */
   public static final class LogLevelTestSecondRunnable extends AbstractTwillRunnable {
     private volatile Thread runThread;

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
@@ -199,7 +199,6 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
       for (TwillRunResources resources : report.getRunnableResources(runnable)) {
         actual = resources.getRootLogLevel();
         actualArgs = resources.getLogLevelArguments();
-        LOG.info("Yaojie - runnable: {} {} == {}, args = {}", runnable, actual, expected, actualArgs);
         if (actual != null && actual.equals(expected) && actualArgs != null) {
           stopped = true;
           break;

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelTestRun.java
@@ -18,10 +18,12 @@
 package org.apache.twill.yarn;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableMap;
 import org.apache.twill.api.AbstractTwillRunnable;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.TwillApplication;
 import org.apache.twill.api.TwillController;
+import org.apache.twill.api.TwillPreparer;
 import org.apache.twill.api.TwillRunResources;
 import org.apache.twill.api.TwillSpecification;
 import org.apache.twill.api.logging.LogEntry;
@@ -34,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -41,6 +44,8 @@ import java.util.concurrent.TimeUnit;
  * Test class whether enable certain log level for application container works.
  */
 public class LogLevelTestRun extends BaseYarnTest {
+
+  private final Map<String, LogEntry.Level> defaultLogArguments = ImmutableMap.of("ROOT", LogEntry.Level.DEBUG);
 
   /**
    * A test of TwillRunnable to see if the DEBUG log level is enabled.
@@ -92,13 +97,36 @@ public class LogLevelTestRun extends BaseYarnTest {
   }
 
   @Test
-  public void testDebugLogLevel()throws Exception {
+  public void testSetRootLogLevel() throws Exception {
+    testLogLevel("ROOT");
+  }
+
+  @Test
+  public void testSetRunnableLogLevel() throws Exception {
+    testLogLevel("RUNNABLE");
+  }
+
+  @Test
+  public void testSetAllLogLevel() throws Exception {
+    testLogLevel("ALL");
+  }
+
+  private void testLogLevel(String method) throws Exception {
     YarnTwillRunnerService runner = getTwillRunner();
     runner.start();
 
+    TwillPreparer preparer = runner.prepare(new LogLevelTestApplication());
+    if (method.equals("ROOT")) {
+      preparer.setLogLevel(LogEntry.Level.DEBUG);
+    }
+    if (method.equals("ALL")) {
+      preparer.setLogLevel(defaultLogArguments);
+    }
+    if (method.equals("RUNNABLE")) {
+      preparer.setLogLevel(LogLevelTestRunnable.class.getSimpleName(), defaultLogArguments);
+    }
     // Set log level to DEBUG
-    TwillController controller = runner.prepare(new LogLevelTestApplication())
-      .setLogLevel(LogEntry.Level.DEBUG)
+    TwillController controller = preparer
       .addLogHandler(new PrinterLogHandler(new PrintWriter(System.out)))
       .start();
 

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelTestRun.java
@@ -137,8 +137,8 @@ public class LogLevelTestRun extends BaseYarnTest {
         continue;
       }
       for (TwillRunResources resources : report.getRunnableResources(runnable)) {
-        if (resources.getLogLevel() != null) {
-           return resources.getLogLevel();
+        if (resources.getRootLogLevel() != null) {
+           return resources.getRootLogLevel();
         }
       }
       TimeUnit.MILLISECONDS.sleep(100);

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/YarnTestSuite.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/YarnTestSuite.java
@@ -34,6 +34,7 @@ import org.junit.runners.Suite;
   InitializeFailTestRun.class,
   LocalFileTestRun.class,
   LogHandlerTestRun.class,
+  LogLevelChangeTestRun.class,
   LogLevelTestRun.class,
   PlacementPolicyTestRun.class,
   ProvisionTimeoutTestRun.class,


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/TWILL-138
https://issues.apache.org/jira/browse/TWILL-195

The first two commits are for TWILL-195, the rest are for TWILL-138.
 
Summary: Make API changes to TwillController and TwillPreparer to set the log level for the twill application or specific twill runnables at runtime or before the application starts. The TwillPreparer will serialize the log level change requirements and deserialize them once service starts. The TwillController will use messages to send out log level change request. Details for implementation can be found in JIRAs.