### PR TITLE
Change initial application submission log message from DEBUG to INFO.

### DIFF
--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
@@ -98,7 +98,7 @@ final class YarnTwillController extends AbstractTwillController implements Twill
 
       YarnApplicationReport report = processController.getReport();
       ApplicationId appId = report.getApplicationId();
-      LOG.debug("Application {} with id {} submitted", appName, appId);
+      LOG.info("Application {} with id {} submitted", appName, appId);
 
       YarnApplicationState state = report.getYarnApplicationState();
       Stopwatch stopWatch = new Stopwatch();


### PR DESCRIPTION
Should be ok to set this log message to INFO, since it only happens once.
In case there is some issue with the yarn app, having this at INFO helps.
There are later logs at INFO, but if the issue causes the code to not reach there, then that isn't sufficient.