### PR TITLE
Fix reset log level for runnables started up later

### DIFF
--- a/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/state/SystemMessages.java
@@ -33,8 +33,8 @@ import javax.annotation.Nullable;
  */
 public final class SystemMessages {
 
-  public static final String LOG_LEVEL = "LOG_LEVEL";
-  public static final String RESET_LOG_LEVEL = "RESET_LOG_LEVEL";
+  public static final String LOG_LEVEL = "logLevels";
+  public static final String RESET_LOG_LEVEL = "resetLogLevels";
   public static final Command STOP_COMMAND = Command.Builder.of("stop").build();
   public static final Message SECURE_STORE_UPDATED = new SimpleMessage(
     Message.Type.SYSTEM, Message.Scope.APPLICATION, null, Command.Builder.of("secureStoreUpdated").build());

--- a/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerService.java
@@ -127,6 +127,7 @@ public final class TwillContainerService extends AbstractYarnTwillService {
             setLogLevel(loggerName, oldLogLevel);
             if (oldLogLevel == null || !defaultLogLevels.containsKey(loggerName)) {
               containerLiveNodeData.removeLogLevel(loggerName);
+              oldLogLevels.remove(loggerName);
             } else {
               containerLiveNodeData.setLogLevel(loggerName, oldLogLevel);
             }
@@ -150,6 +151,7 @@ public final class TwillContainerService extends AbstractYarnTwillService {
       }
 
       updateLiveNode();
+      return Futures.immediateFuture(messageId);
     }
 
     commandExecutor.execute(new Runnable() {
@@ -171,7 +173,11 @@ public final class TwillContainerService extends AbstractYarnTwillService {
   @Override
   protected void doStart() throws Exception {
     for (Map.Entry<String, String> entry : containerLiveNodeData.getLogLevels().entrySet()) {
-      setLogLevel(entry.getKey(), entry.getValue());
+      String loggerName = entry.getKey();
+      String oldLogLevel = setLogLevel(loggerName, entry.getValue());
+      if (!defaultLogLevels.containsKey(loggerName)) {
+        oldLogLevels.put(loggerName, oldLogLevel);
+      }
     }
 
     commandExecutor = Executors.newSingleThreadExecutor(

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
@@ -225,12 +225,13 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
 
     // change the log level of LogLevelTestSecondRunnable to DEBUG and change instances of it to test if the log level
     // request get applied to container started up later
-    logLevelSecondRunnable = ImmutableMap.of(Logger.ROOT_LOGGER_NAME, LogEntry.Level.DEBUG);
+    logLevelSecondRunnable = ImmutableMap.of(Logger.ROOT_LOGGER_NAME, LogEntry.Level.DEBUG, "test",
+                                             LogEntry.Level.WARN);
     controller.updateLogLevels(LogLevelTestSecondRunnable.class.getSimpleName(), logLevelSecondRunnable).get();
     controller.changeInstances(LogLevelTestSecondRunnable.class.getSimpleName(), 2).get();
     TimeUnit.SECONDS.sleep(5);
-    waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(),
-                    20L, TimeUnit.SECONDS, LogEntry.Level.DEBUG, ImmutableMap.of("ROOT", LogEntry.Level.DEBUG));
+    waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(), 20L, TimeUnit.SECONDS,
+                    LogEntry.Level.DEBUG, logLevelSecondRunnable);
 
     // reset the log levels back to default.
     controller.resetLogLevels().get();


### PR DESCRIPTION
There is a bug when we try to reset log levels for some runnables which are started up later, e.g, restart or instance changes, after some runtime log level changes. For now, when we start up the `TwillContainerService`, we set log levels based on the what we try to set in `TwillPreparer` + runtime log levels. But we do not memorize the old log level for loggers changed at runtime. So we we reset, we will not get back to the state we want.
This PR fixes this by memorizing the log level changes coming from runtime. And remove when we call reset.
