### PR TITLE
Remove unnecessary methods to get the root log level

### DIFF
--- a/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
@@ -233,12 +233,12 @@ public abstract class ServiceMain {
   }
 
   /**
-   * Override to return the right log level for the service.
+   * Return the right log level for the service.
    *
    * @param logger the {@link Logger} instance of the service context.
    * @return String of log level based on {@code slf4j} log levels.
    */
-  protected String getLoggerLevel(Logger logger) {
+  private String getLoggerLevel(Logger logger) {
     if (logger instanceof ch.qos.logback.classic.Logger) {
       return ((ch.qos.logback.classic.Logger) logger).getLevel().toString();
     }

--- a/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
@@ -65,8 +65,6 @@ public final class TwillContainerMain extends ServiceMain {
 
   private static final Logger LOG = LoggerFactory.getLogger(TwillContainerMain.class);
 
-  private final Map<String, String> logLevels = new HashMap<>();
-
   /**
    * Main method for launching a {@link TwillContainerService} which runs
    * a {@link org.apache.twill.api.TwillRunnable}.
@@ -89,6 +87,7 @@ public final class TwillContainerMain extends ServiceMain {
     Map<String, String> defaultLogLevels = twillRuntimeSpec.getLogLevels().get(runnableName);
     Map<String, String> dynamicLogLevels = loadLogLevels().get(runnableName);
 
+    Map<String, String> logLevels = new HashMap<>();
     logLevels.putAll(defaultLogLevels);
     if (dynamicLogLevels != null) {
       logLevels.putAll(dynamicLogLevels);
@@ -98,7 +97,7 @@ public final class TwillContainerMain extends ServiceMain {
     ZKDiscoveryService discoveryService = new ZKDiscoveryService(zkClientService);
 
     ZKClient appRunZkClient = getAppRunZKClient(zkClientService, appRunId);
-    
+
     TwillRunnableSpecification runnableSpec =
       twillRuntimeSpec.getTwillSpecification().getRunnables().get(runnableName).getRunnableSpecification();
     ContainerInfo containerInfo = new EnvContainerInfo();
@@ -125,12 +124,6 @@ public final class TwillContainerMain extends ServiceMain {
       new TwillZKPathService(containerZKClient, runId),
       new CloseableServiceWrapper(discoveryService)
     );
-  }
-
-  @Override
-  protected String getLoggerLevel(Logger logger) {
-    String logLevel = logLevels.get(Logger.ROOT_LOGGER_NAME);
-    return logLevel == null ? super.getLoggerLevel(logger) : logLevel;
   }
 
   private static void loadSecureStore() throws IOException {

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/LogLevelChangeTestRun.java
@@ -102,9 +102,6 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
     public void run() {
       this.runThread = Thread.currentThread();
 
-      // check if the initial log level is DEBUG
-      Assert.assertTrue(LOG.isDebugEnabled() && !LOG.isTraceEnabled());
-
       int i = 0;
       while (!Thread.interrupted()) {
         if (i == 0 && !LOG.isDebugEnabled()) {
@@ -223,15 +220,15 @@ public class LogLevelChangeTestRun extends BaseYarnTest {
     waitForLogLevel(controller, LogLevelTestRunnable.class.getSimpleName(),
                     20L, TimeUnit.SECONDS, LogEntry.Level.WARN, result);
 
-    // change the log level of LogLevelTestSecondRunnable to DEBUG and change instances of it to test if the log level
+    // change the log level of LogLevelTestSecondRunnable to INFO and change instances of it to test if the log level
     // request get applied to container started up later
-    logLevelSecondRunnable = ImmutableMap.of(Logger.ROOT_LOGGER_NAME, LogEntry.Level.DEBUG, "test",
+    logLevelSecondRunnable = ImmutableMap.of(Logger.ROOT_LOGGER_NAME, LogEntry.Level.INFO, "test",
                                              LogEntry.Level.WARN);
     controller.updateLogLevels(LogLevelTestSecondRunnable.class.getSimpleName(), logLevelSecondRunnable).get();
     controller.changeInstances(LogLevelTestSecondRunnable.class.getSimpleName(), 2).get();
     TimeUnit.SECONDS.sleep(5);
     waitForLogLevel(controller, LogLevelTestSecondRunnable.class.getSimpleName(), 20L, TimeUnit.SECONDS,
-                    LogEntry.Level.DEBUG, logLevelSecondRunnable);
+                    LogEntry.Level.INFO, logLevelSecondRunnable);
 
     // reset the log levels back to default.
     controller.resetLogLevels().get();


### PR DESCRIPTION
Since we are now setting the log level once the `TwillContainerService` starts up. We no longer need the get root log level from `TwillContainerMain`.