### PR TITLE
Fix location permission test for older Hadoop versions

### DIFF
--- a/twill-yarn/src/test/java/org/apache/twill/filesystem/FileContextLocationTest.java
+++ b/twill-yarn/src/test/java/org/apache/twill/filesystem/FileContextLocationTest.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.twill.internal.yarn.YarnUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -89,5 +90,15 @@ public class FileContextLocationTest extends LocationTestBase {
 
   protected LocationFactory doCreateLocationFactory(String pathBase) throws IOException {
     return new FileContextLocationFactory(dfsCluster.getFileSystem().getConf(), pathBase);
+  }
+
+  @Override
+  protected String correctFilePermissions(String original) {
+    if (YarnUtils.HadoopVersions.HADOOP_20.equals(YarnUtils.getHadoopVersion())) {
+      return original.substring(0, 2) + '-' + // strip the x for owner
+        original.substring(3, 5) + '-' + // strip the x for group
+        original.substring(6, 8) + '-'; // strip the x for world;
+    }
+    return original;
   }
 }

--- a/twill-yarn/src/test/java/org/apache/twill/filesystem/LocationTestBase.java
+++ b/twill-yarn/src/test/java/org/apache/twill/filesystem/LocationTestBase.java
@@ -300,7 +300,7 @@ public abstract class LocationTestBase {
     Assert.assertFalse(textfile.isDirectory());
     Assert.assertEquals(permissions, child.getPermissions());
     Assert.assertEquals(permissions, grandchild.getPermissions());
-    Assert.assertEquals(permissions, textfile.getPermissions());
+    Assert.assertEquals(correctFilePermissions(permissions), textfile.getPermissions());
 
     // mkdirs of existing file
     Location file = factory.create("existingfile");
@@ -363,4 +363,12 @@ public abstract class LocationTestBase {
    * If no suitable group name is known, the passed-in group name can be returned.
    */
   protected abstract String getUserGroup(String groupName);
+
+  /**
+   * Some older versions of Hadoop always strip the execute permission from files (but keep it for directories).
+   * This allows subclasses to correct the expected file permissions, based on the Hadoop version (if any).
+   */
+  protected String correctFilePermissions(String expectedFilePermissions) {
+    return expectedFilePermissions; // unchanged by default
+  }
 }


### PR DESCRIPTION
In older Hadoop versions (2.0), files are always created with permissions that do not have execute bits. In later Hadoop versions, execute permissions are permitted for files. This changes the test location permission case to adjust the expected permissions for the missing execute bits, based on the Hadoop version.  

Also fixes an intriguing bug where creating a directory (say a/b/c/) one of whose parents (say a/b) already exists as a file, Hadoop throws an access control exception. This is because the execute bit is not set on files. We must expect that exception and handle it properly. 