### PR TITLE
Avoid packaging resources jar in the ApplicationMaster

### DIFF
--- a/twill-core/src/main/java/org/apache/twill/launcher/TwillLauncher.java
+++ b/twill-core/src/main/java/org/apache/twill/launcher/TwillLauncher.java
@@ -96,10 +96,14 @@ public final class TwillLauncher {
     });
 
     // Add the app jar, resources jar and twill jar directories to the classpath as well
-    for (File dir : Arrays.asList(appJarDir, resourceJarDir, twillJarDir)) {
+    for (File dir : Arrays.asList(appJarDir, twillJarDir)) {
       urls.add(dir.toURI().toURL());
       urls.add(new File(dir, "classes").toURI().toURL());
-      urls.add(new File(dir, "resources").toURI().toURL());
+    }
+
+    // this indicates that we are not in the ApplicationMaster
+    if (useClassPath) {
+      urls.add(new File(resourceJarDir, "resources").toURI().toURL());
     }
 
     // Add all lib jars


### PR DESCRIPTION
Avoid packaging resources jar in the ApplicationMaster, so that the logback.xml in it doesn't affect the AM.
Otherwise, the stdout of the AM omits a lot of logs.