### PR TITLE
(TWILL-218), add the OptionSpec class as an explicit dependency for the…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
         <kafka.version>0.8.0</kafka.version>
         <zookeeper.version>3.4.5</zookeeper.version>
         <junit.version>4.11</junit.version>
+        <jopt-simple.version>3.2</jopt-simple.version>
         <commons-compress.version>1.5</commons-compress.version>
         <hadoop.version>[2.0.2-alpha,2.3.0]</hadoop.version>
         <hadoop20.output.dir>target/hadoop20-classes</hadoop20.output.dir>
@@ -803,6 +804,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+	    <dependency>
+	      <groupId>net.sf.jopt-simple</groupId>
+	      <artifactId>jopt-simple</artifactId>
+	      <version>${jopt-simple.version}</version>
+	    </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-yarn-api</artifactId>

--- a/twill-core/pom.xml
+++ b/twill-core/pom.xml
@@ -81,6 +81,11 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
         </dependency>
+	<!-- https://mvnrepository.com/artifact/net.sf.jopt-simple/jopt-simple -->
+	<dependency>
+	  <groupId>net.sf.jopt-simple</groupId>
+	  <artifactId>jopt-simple</artifactId>
+	</dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
@@ -20,7 +20,6 @@ package org.apache.twill.yarn;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
@@ -40,6 +39,7 @@ import com.google.common.io.OutputSupplier;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -112,6 +112,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
+
+import joptsimple.OptionSpec;
 
 /**
  * Implementation for {@link TwillPreparer} to prepare and launch distributed application on Hadoop YARN.
@@ -482,7 +484,7 @@ final class YarnTwillPreparer implements TwillPreparer {
       public void load(String name, Location targetLocation) throws IOException {
         // Stuck in the yarnAppClient class to make bundler being able to pickup the right yarn-client version
         bundler.createBundle(targetLocation, ApplicationMasterMain.class,
-                             yarnAppClient.getClass(), TwillContainerMain.class);
+          yarnAppClient.getClass(), TwillContainerMain.class, OptionSpec.class);
       }
     });
 


### PR DESCRIPTION
… appmaster

I added the jar to the respective poms and added OptionSpec to the appmaster dependency calculation.  The dependency shows up because of Kafka:

    [INFO] |  |  \- org.apache.kafka:kafka_2.10:jar:0.8.0:compile
    [INFO] |  |     +- org.scala-lang:scala-library:jar:2.10.1:compile
    [INFO] |  |     +- net.sf.jopt-simple:jopt-simple:jar:3.2:compile
    [INFO] |  |     +- org.scala-lang:scala-compiler:jar:2.10.1:compile
    [INFO] |  |     |  \- org.scala-lang:scala-reflect:jar:2.10.1:compile
    [INFO] |  |     +- com.101tec:zkclient:jar:0.3:compile
    [INFO] |  |     +- com.yammer.metrics:metrics-core:jar:2.2.0:compile
    [INFO] |  |     \- com.yammer.metrics:metrics-annotation:jar:2.2.0:compile

However the twill dependency mechanism does not detect the dependency.  By making it explicit, it will always end up in the `twill.jar`