### PR TITLE
(Twill-222) fix for default root log level

### DIFF
--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
@@ -650,9 +650,6 @@ public final class ApplicationMasterService extends AbstractYarnTwillService imp
       String runnableName = provisionRequest.getRuntimeSpec().getName();
       LOG.info("Starting runnable {} in {}", runnableName, processLauncher.getContainerInfo().getContainer());
 
-      LOG.debug("Log level for Twill runnable {} is {}", runnableName,
-                twillRuntimeSpec.getLogLevels().get(runnableName).get(Logger.ROOT_LOGGER_NAME));
-
       int containerCount = expectedContainers.getExpected(runnableName);
 
       // Setup container environment variables

--- a/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
@@ -18,6 +18,7 @@
 package org.apache.twill.internal.container;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -88,7 +89,11 @@ public final class TwillContainerMain extends ServiceMain {
     Map<String, String> dynamicLogLevels = loadLogLevels().get(runnableName);
 
     Map<String, String> logLevels = new HashMap<>();
-    logLevels.putAll(defaultLogLevels);
+    if (defaultLogLevels != null) {
+      logLevels.putAll(defaultLogLevels);
+    } else {
+      defaultLogLevels = ImmutableMap.of();
+    }
     if (dynamicLogLevels != null) {
       logLevels.putAll(dynamicLogLevels);
     }

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
@@ -178,9 +178,6 @@ final class YarnTwillPreparer implements TwillPreparer {
     this.classAcceptor = new ClassAcceptor();
     this.locationCache = locationCache;
     this.twillClassPaths = twillClassPaths;
-
-    // By default, the root logger is having INFO log level
-    setLogLevel(LogEntry.Level.INFO);
   }
 
   private void confirmRunnableName(String runnableName) {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/TWILL-222

We should not assume the root log level as INFO in TwillPreparer. Removed the INFO level from TwillPreparer to not override what is in the logback.xml.