### PR TITLE
(TWILL-122) Allow disabling log collection

### DIFF
--- a/twill-api/src/main/java/org/apache/twill/api/Configs.java
+++ b/twill-api/src/main/java/org/apache/twill/api/Configs.java
@@ -78,6 +78,11 @@ public final class Configs {
      */
     public static final String YARN_AM_RESERVED_MEMORY_MB = "twill.yarn.am.reserved.memory.mb";
 
+    /**
+     * Setting for enabling log collection.
+     */
+    public static final String LOG_COLLECTION_ENABLED = "twill.log.collection.enabled";
+
     private Keys() {
     }
   }
@@ -116,6 +121,11 @@ public final class Configs {
      * Default AM JVM reserved memory.
      */
     public static final int YARN_AM_RESERVED_MEMORY_MB = 150;
+
+    /**
+     * Default to enable log collection.
+     */
+    public static final boolean LOG_COLLECTION_ENABLED = true;
 
 
     private Defaults() {

--- a/twill-core/src/main/java/org/apache/twill/internal/EnvKeys.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/EnvKeys.java
@@ -31,8 +31,6 @@ public final class EnvKeys {
    */
   public static final String TWILL_RUNNABLE_NAME = "TWILL_RUNNABLE_NAME";
 
-  public static final String TWILL_LOG_KAFKA_ZK = "TWILL_LOG_KAFKA_ZK";
-
   public static final String YARN_APP_ID = "YARN_APP_ID";
   public static final String YARN_APP_ID_CLUSTER_TIME = "YARN_APP_ID_CLUSTER_TIME";
   public static final String YARN_APP_ID_STR = "YARN_APP_ID_STR";

--- a/twill-core/src/main/java/org/apache/twill/internal/TwillRuntimeSpecification.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/TwillRuntimeSpecification.java
@@ -41,13 +41,14 @@ public class TwillRuntimeSpecification {
   private final String rmSchedulerAddr;
   private final Map<String, Map<String, String>> logLevels;
   private final Map<String, Integer> maxRetries;
-  private double minHeapRatio;
+  private final double minHeapRatio;
+  private final boolean logCollectionEnabled;
 
   public TwillRuntimeSpecification(TwillSpecification twillSpecification, String fsUser, URI twillAppDir,
                                    String zkConnectStr, RunId twillRunId, String twillAppName,
                                    int reservedMemory, @Nullable String rmSchedulerAddr,
                                    Map<String, Map<String, String>> logLevels, Map<String, Integer> maxRetries,
-                                   double minHeapRatio) {
+                                   double minHeapRatio, boolean logCollectionEnabled) {
     this.twillSpecification = twillSpecification;
     this.fsUser = fsUser;
     this.twillAppDir = twillAppDir;
@@ -59,6 +60,7 @@ public class TwillRuntimeSpecification {
     this.logLevels = logLevels;
     this.maxRetries = maxRetries;
     this.minHeapRatio = minHeapRatio;
+    this.logCollectionEnabled = logCollectionEnabled;
   }
 
   public TwillSpecification getTwillSpecification() {
@@ -93,6 +95,13 @@ public class TwillRuntimeSpecification {
     return minHeapRatio;
   }
 
+  /**
+   * Returns whether log collection is enabled.
+   */
+  public boolean isLogCollectionEnabled() {
+    return logCollectionEnabled;
+  }
+
   @Nullable
   public String getRmSchedulerAddr() {
     return rmSchedulerAddr;
@@ -104,5 +113,18 @@ public class TwillRuntimeSpecification {
 
   public Map<String, Integer> getMaxRetries() {
     return maxRetries;
+  }
+
+  /**
+   * Returns the ZK connection string for the Kafka used for log collections,
+   * or {@code null} if log collection is disabled.
+   */
+  @Nullable
+  public String getKafkaZKConnect() {
+    if (!isLogCollectionEnabled()) {
+      return null;
+    }
+    // When addressing TWILL-147, a field can be introduced to carry this value.
+    return String.format("%s/%s/%s/kafka", getZkConnectStr(), getTwillAppName(), getTwillAppRunId());
   }
 }

--- a/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/json/TwillRuntimeSpecificationCodec.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import org.apache.twill.api.Configs;
 import org.apache.twill.api.TwillSpecification;
 import org.apache.twill.internal.RunIds;
 import org.apache.twill.internal.TwillRuntimeSpecification;
@@ -51,6 +50,7 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
   private static final String TWILL_SPEC = "twillSpecification";
   private static final String LOG_LEVELS = "logLevels";
   private static final String MAX_RETRIES = "maxRetries";
+  private static final String LOG_COLLECTION_ENABLED = "logCollectionEnabled";
 
   @Override
   public JsonElement serialize(TwillRuntimeSpecification src, Type typeOfSrc, JsonSerializationContext context) {
@@ -71,6 +71,7 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
              context.serialize(src.getLogLevels(), new TypeToken<Map<String, Map<String, String>>>() { }.getType()));
     json.add(MAX_RETRIES,
              context.serialize(src.getMaxRetries(), new TypeToken<Map<String, Integer>>() { }.getType()));
+    json.addProperty(LOG_COLLECTION_ENABLED, src.isLogCollectionEnabled());
 
     return json;
   }
@@ -98,8 +99,7 @@ final class TwillRuntimeSpecificationCodec implements JsonSerializer<TwillRuntim
                                          jsonObj.get(RM_SCHEDULER_ADDR).getAsString() : null,
                                          logLevels,
                                          maxRetries,
-                                         jsonObj.has(HEAP_RESERVED_MIN_RATIO) ?
-                                         jsonObj.get(HEAP_RESERVED_MIN_RATIO).getAsDouble()
-                                         : Configs.Defaults.HEAP_RESERVED_MIN_RATIO);
+                                         jsonObj.get(HEAP_RESERVED_MIN_RATIO).getAsDouble(),
+                                         jsonObj.get(LOG_COLLECTION_ENABLED).getAsBoolean());
   }
 }

--- a/twill-core/src/test/java/org/apache/twill/internal/ControllerTest.java
+++ b/twill-core/src/test/java/org/apache/twill/internal/ControllerTest.java
@@ -62,7 +62,7 @@ public class ControllerTest {
       Service service = createService(zkClientService, runId);
       service.startAndWait();
 
-      TwillController controller = getController(zkClientService, runId);
+      TwillController controller = getController(zkClientService, "testController", runId);
       controller.sendCommand(Command.Builder.of("test").build()).get(2, TimeUnit.SECONDS);
       controller.terminate().get(2, TimeUnit.SECONDS);
 
@@ -96,7 +96,7 @@ public class ControllerTest {
       zkClientService.startAndWait();
 
       final CountDownLatch runLatch = new CountDownLatch(1);
-      TwillController controller = getController(zkClientService, runId);
+      TwillController controller = getController(zkClientService, "testControllerBefore", runId);
       controller.onRunning(new Runnable() {
         @Override
         public void run() {
@@ -140,7 +140,7 @@ public class ControllerTest {
       service.startAndWait();
 
       final CountDownLatch runLatch = new CountDownLatch(1);
-      TwillController controller = getController(zkClientService, runId);
+      TwillController controller = getController(zkClientService, "testControllerListener", runId);
       controller.onRunning(new Runnable() {
         @Override
         public void run() {
@@ -185,8 +185,9 @@ public class ControllerTest {
     };
   }
 
-  private TwillController getController(ZKClient zkClient, RunId runId) {
-    AbstractTwillController controller = new AbstractTwillController(runId, zkClient, ImmutableList.<LogHandler>of()) {
+  private TwillController getController(ZKClient zkClient, String appName, RunId runId) {
+    AbstractTwillController controller = new AbstractTwillController(appName, runId,
+                                                                     zkClient, false, ImmutableList.<LogHandler>of()) {
 
       @Override
       public void kill() {

--- a/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
@@ -18,9 +18,6 @@
 package org.apache.twill.internal;
 
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.classic.util.ContextInitializer;
-import ch.qos.logback.core.joran.spi.JoranException;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.Futures;
@@ -45,14 +42,13 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.InputSource;
 
 import java.io.File;
-import java.io.StringReader;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * Class for main method that starts a service.
@@ -70,7 +66,10 @@ public abstract class ServiceMain {
 
   protected final void doMain(final Service mainService,
                               Service...prerequisites) throws ExecutionException, InterruptedException {
-    configureLogger();
+    // Only configure the log collection if it is enabled.
+    if (getTwillRuntimeSpecification().isLogCollectionEnabled()) {
+      configureLogger();
+    }
 
     Service requiredServices = new CompositeService(prerequisites);
     Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -121,14 +120,21 @@ public abstract class ServiceMain {
 
   protected abstract String getHostname();
 
-  protected abstract String getKafkaZKConnect();
+  /**
+   * Returns the {@link TwillRuntimeSpecification} for this application.
+   */
+  protected abstract TwillRuntimeSpecification getTwillRuntimeSpecification();
 
+  /**
+   * Returns the name of the runnable that this running inside this process.
+   */
+  @Nullable
   protected abstract String getRunnableName();
 
   /**
    * Returns the {@link Location} for the application based on the app directory.
    */
-  protected static Location createAppLocation(final Configuration conf, String fsUser, final URI appDir) {
+  protected final Location createAppLocation(final Configuration conf, String fsUser, final URI appDir) {
     // Note: It's a little bit hacky based on the uri schema to create the LocationFactory, refactor it later.
 
     try {
@@ -168,16 +174,19 @@ public abstract class ServiceMain {
   /**
    * Creates a {@link ZKClientService}.
    */
-  protected static ZKClientService createZKClient(String zkConnectStr, String appName) {
+  protected final ZKClientService createZKClient() {
+    TwillRuntimeSpecification twillRuntimeSpec = getTwillRuntimeSpecification();
+
     return ZKClientServices.delegate(
       ZKClients.namespace(
         ZKClients.reWatchOnExpire(
           ZKClients.retryOnFailure(
-            ZKClientService.Builder.of(zkConnectStr).build(),
+            ZKClientService.Builder.of(twillRuntimeSpec.getZkConnectStr()).build(),
             RetryStrategies.fixDelay(1, TimeUnit.SECONDS)
           )
-        ), "/" + appName
-      ));
+        ), "/" + twillRuntimeSpec.getTwillAppName()
+      )
+    );
   }
 
   private void configureLogger() {
@@ -188,84 +197,23 @@ public abstract class ServiceMain {
     }
 
     LoggerContext context = (LoggerContext) loggerFactory;
-    context.reset();
-    JoranConfigurator configurator = new JoranConfigurator();
-    configurator.setContext(context);
 
-    try {
-      File twillLogback = new File(Constants.Files.RUNTIME_CONFIG_JAR, Constants.Files.LOGBACK_TEMPLATE);
-      if (twillLogback.exists()) {
-        configurator.doConfigure(twillLogback);
-      }
-      new ContextInitializer(context).autoConfig();
-    } catch (JoranException e) {
-      throw Throwables.propagate(e);
-    }
-    doConfigure(configurator, getLogConfig(getLoggerLevel(context.getLogger(Logger.ROOT_LOGGER_NAME))));
-  }
-
-  private void doConfigure(JoranConfigurator configurator, String config) {
-    try {
-      configurator.doConfigure(new InputSource(new StringReader(config)));
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  private String getLogConfig(String rootLevel) {
-    return
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-      "<configuration>\n" +
-      "    <appender name=\"KAFKA\" class=\"" + KafkaAppender.class.getName() + "\">\n" +
-      "        <topic>" + Constants.LOG_TOPIC + "</topic>\n" +
-      "        <hostname>" + getHostname() + "</hostname>\n" +
-      "        <zookeeper>" + getKafkaZKConnect() + "</zookeeper>\n" +
-      appendRunnable() +
-      "    </appender>\n" +
-      "    <logger name=\"org.apache.twill.internal.logging\" additivity=\"false\" />\n" +
-      "    <root level=\"" + rootLevel + "\">\n" +
-      "        <appender-ref ref=\"KAFKA\"/>\n" +
-      "    </root>\n" +
-      "</configuration>";
-  }
-
-
-  private String appendRunnable() {
-    // RunnableName for AM is null, so append runnable name to log config only if the name is not null.
-    if (getRunnableName() == null) {
-     return "";
-    } else {
-      return "        <runnableName>" + getRunnableName() + "</runnableName>\n";
-    }
-  }
-
-  /**
-   * Return the right log level for the service.
-   *
-   * @param logger the {@link Logger} instance of the service context.
-   * @return String of log level based on {@code slf4j} log levels.
-   */
-  private String getLoggerLevel(Logger logger) {
-    if (logger instanceof ch.qos.logback.classic.Logger) {
-      return ((ch.qos.logback.classic.Logger) logger).getLevel().toString();
+    // Attach the KafkaAppender to the root logger
+    KafkaAppender kafkaAppender = new KafkaAppender();
+    kafkaAppender.setName("KAFKA");
+    kafkaAppender.setTopic(Constants.LOG_TOPIC);
+    kafkaAppender.setHostname(getHostname());
+    // The Kafka ZK Connection shouldn't be null as this method only get called if log collection is enabled
+    kafkaAppender.setZookeeper(getTwillRuntimeSpecification().getKafkaZKConnect());
+    String runnableName = getRunnableName();
+    if (runnableName != null) {
+      kafkaAppender.setRunnableName(runnableName);
     }
 
-    if (logger.isTraceEnabled()) {
-      return "TRACE";
-    }
-    if (logger.isDebugEnabled()) {
-      return "DEBUG";
-    }
-    if (logger.isInfoEnabled()) {
-      return "INFO";
-    }
-    if (logger.isWarnEnabled()) {
-      return "WARN";
-    }
-    if (logger.isErrorEnabled()) {
-      return "ERROR";
-    }
-    return "OFF";
+    kafkaAppender.setContext(context);
+    kafkaAppender.start();
+
+    context.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME).addAppender(kafkaAppender);
   }
 
   /**

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterLiveNodeData.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterLiveNodeData.java
@@ -20,6 +20,7 @@ package org.apache.twill.internal.appmaster;
 import org.apache.twill.api.LocalFile;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Represents data being stored in the live node of the application master.
@@ -30,13 +31,16 @@ public final class ApplicationMasterLiveNodeData {
   private final long appIdClusterTime;
   private final String containerId;
   private final List<LocalFile> localFiles;
+  private final String kafkaZKConnect;
 
   public ApplicationMasterLiveNodeData(int appId, long appIdClusterTime,
-                                       String containerId, List<LocalFile> localFiles) {
+                                       String containerId, List<LocalFile> localFiles,
+                                       @Nullable String kafkaZKConnect) {
     this.appId = appId;
     this.appIdClusterTime = appIdClusterTime;
     this.containerId = containerId;
     this.localFiles = localFiles;
+    this.kafkaZKConnect = kafkaZKConnect;
   }
 
   public int getAppId() {
@@ -53,6 +57,15 @@ public final class ApplicationMasterLiveNodeData {
 
   public List<LocalFile> getLocalFiles() {
     return localFiles;
+  }
+
+  /**
+   * @return the Kafka ZK connection string for the Kafka used for log collection;
+   *         if log collection is turned off, a {@code null} value will be returned.
+   */
+  @Nullable
+  public String getKafkaZKConnect() {
+    return kafkaZKConnect;
   }
 
   @Override

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterService.java
@@ -157,7 +157,8 @@ public final class ApplicationMasterService extends AbstractYarnTwillService imp
 
     this.amLiveNode = new ApplicationMasterLiveNodeData(Integer.parseInt(System.getenv(EnvKeys.YARN_APP_ID)),
                                                         Long.parseLong(System.getenv(EnvKeys.YARN_APP_ID_CLUSTER_TIME)),
-                                                        amClient.getContainerId().toString(), getLocalizeFiles());
+                                                        amClient.getContainerId().toString(), getLocalizeFiles(),
+                                                        twillRuntimeSpec.getKafkaZKConnect());
 
     this.expectedContainers = new ExpectedContainers(twillSpec);
     this.runningContainers = createRunningContainers(amClient.getContainerId(), amClient.getHost());
@@ -657,8 +658,6 @@ public final class ApplicationMasterService extends AbstractYarnTwillService imp
       if (environments.containsKey(runnableName)) {
         env.putAll(environments.get(runnableName));
       }
-      // Override with system env
-      env.put(EnvKeys.TWILL_LOG_KAFKA_ZK, getKafkaZKConnect());
 
       ProcessLauncher.PrepareLaunchContext launchContext = processLauncher.prepareLaunch(env,
                                                                                          amLiveNode.getLocalFiles(),
@@ -712,10 +711,6 @@ public final class ApplicationMasterService extends AbstractYarnTwillService imp
 
   private String getZKNamespace(String runnableName) {
     return String.format("/%s/runnables/%s", runId.getId(), runnableName);
-  }
-
-  String getKafkaZKConnect() {
-    return String.format("%s/%s/kafka", zkClient.getConnectString(), runId.getId());
   }
 
   /**

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
@@ -77,7 +77,7 @@ final class YarnTwillController extends AbstractTwillController implements Twill
    */
   YarnTwillController(String appName, RunId runId, ZKClient zkClient,
                       final ApplicationMasterLiveNodeData amLiveNodeData, final YarnAppClient yarnAppClient) {
-    super(runId, zkClient, Collections.<LogHandler>emptyList());
+    super(appName, runId, zkClient, amLiveNodeData.getKafkaZKConnect() != null, Collections.<LogHandler>emptyList());
     this.appName = appName;
     this.amLiveNodeData = amLiveNodeData;
     this.startUp = new Callable<ProcessController<YarnApplicationReport>>() {
@@ -91,10 +91,10 @@ final class YarnTwillController extends AbstractTwillController implements Twill
     this.startTimeoutUnit = TimeUnit.SECONDS;
   }
 
-  YarnTwillController(String appName, RunId runId, ZKClient zkClient, Iterable<LogHandler> logHandlers,
-                      Callable<ProcessController<YarnApplicationReport>> startUp,
+  YarnTwillController(String appName, RunId runId, ZKClient zkClient, boolean logCollectionEnabled,
+                      Iterable<LogHandler> logHandlers, Callable<ProcessController<YarnApplicationReport>> startUp,
                       long startTimeout, TimeUnit startTimeoutUnit) {
-    super(runId, zkClient, logHandlers);
+    super(appName, runId, zkClient, logCollectionEnabled, logHandlers);
     this.appName = appName;
     this.startUp = startUp;
     this.startTimeout = startTimeout;

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillControllerFactory.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillControllerFactory.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  */
 interface YarnTwillControllerFactory {
 
-  YarnTwillController create(RunId runId, Iterable<LogHandler> logHandlers,
+  YarnTwillController create(RunId runId, boolean logCollectionEnabled, Iterable<LogHandler> logHandlers,
                              Callable<ProcessController<YarnApplicationReport>> startUp,
                              long startTimeout, TimeUnit startTimeoutUnit);
 }

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
@@ -419,7 +419,10 @@ final class YarnTwillPreparer implements TwillPreparer {
           }
         };
 
-      YarnTwillController controller = controllerFactory.create(runId, logHandlers, submitTask, timeout, timeoutUnit);
+      boolean logCollectionEnabled = config.getBoolean(Configs.Keys.LOG_COLLECTION_ENABLED,
+                                                       Configs.Defaults.LOG_COLLECTION_ENABLED);
+      YarnTwillController controller = controllerFactory.create(runId, logCollectionEnabled,
+                                                                logHandlers, submitTask, timeout, timeoutUnit);
       controller.start();
       return controller;
     } catch (Exception e) {
@@ -671,11 +674,13 @@ final class YarnTwillPreparer implements TwillPreparer {
       }
       TwillSpecification newTwillSpec = new DefaultTwillSpecification(spec.getName(), runtimeSpec, spec.getOrders(),
                                                                       spec.getPlacementPolicies(), eventHandler);
+      boolean logCollectionEnabled = config.getBoolean(Configs.Keys.LOG_COLLECTION_ENABLED,
+                                                       Configs.Defaults.LOG_COLLECTION_ENABLED);
       TwillRuntimeSpecificationAdapter.create().toJson(
         new TwillRuntimeSpecification(newTwillSpec, appLocation.getLocationFactory().getHomeLocation().getName(),
                                       appLocation.toURI(), zkConnectString, runId, twillSpec.getName(),
                                       getReservedMemory(), config.get(YarnConfiguration.RM_SCHEDULER_ADDRESS),
-                                      logLevels, maxRetries, getMinHeapRatio()), writer);
+                                      logLevels, maxRetries, getMinHeapRatio(), logCollectionEnabled), writer);
     }
     LOG.debug("Done {}", targetFile);
   }

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
@@ -291,11 +291,12 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
                                  appLocation, twillClassPaths, jvmOptions,
                                  locationCache, new YarnTwillControllerFactory() {
       @Override
-      public YarnTwillController create(RunId runId, Iterable<LogHandler> logHandlers,
+      public YarnTwillController create(RunId runId, boolean logCollectionEnabled, Iterable<LogHandler> logHandlers,
                                         Callable<ProcessController<YarnApplicationReport>> startUp,
                                         long startTimeout, TimeUnit startTimeoutUnit) {
         ZKClient zkClient = ZKClients.namespace(zkClientService, "/" + appName);
         YarnTwillController controller = listenController(new YarnTwillController(appName, runId, zkClient,
+                                                                                  logCollectionEnabled,
                                                                                   logHandlers, startUp,
                                                                                   startTimeout, startTimeoutUnit));
         synchronized (YarnTwillRunnerService.this) {


### PR DESCRIPTION
- Introduced a new configuration twill.log.collection.enabled for
  turning off log collection
- Refactor YarnTwillController and related class hierarchy to not
  starting Kafka client when log collection is disabled
- Added Kafka zk connection string information in AM live node data
- Refactor KafkaAppender and ServiceMain configureLogger
  - Log to StatusManager instead of Logger to avoid recursive logging
  - Instead of resetting logback configuration, directly instantiate and
    add the Kafka log appender to the logging context.
- Refactor ServiceMain, ApplicationMasterMain and TwillContainerMain to
  simplify ZK Connection string construction