### PR TITLE
(TWILL-223) Make FileContextLocationFactory UGI aware

### DIFF
--- a/twill-api/src/main/java/org/apache/twill/api/Configs.java
+++ b/twill-api/src/main/java/org/apache/twill/api/Configs.java
@@ -83,6 +83,11 @@ public final class Configs {
      */
     public static final String LOG_COLLECTION_ENABLED = "twill.log.collection.enabled";
 
+    /**
+     * The maximum number of FileContext object cached by the FileContextLocationFactory.
+     */
+    public static final String FILE_CONTEXT_CACHE_MAX_SIZE = "twill.file.context.cache.max.size";
+
     private Keys() {
     }
   }
@@ -126,6 +131,11 @@ public final class Configs {
      * Default to enable log collection.
      */
     public static final boolean LOG_COLLECTION_ENABLED = true;
+
+    /**
+     * Default size of the file context cache.
+     */
+    public static final int FILE_CONTEXT_CACHE_MAX_SIZE = 100;
 
 
     private Defaults() {

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
@@ -674,7 +674,8 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
   private static LocationFactory createDefaultLocationFactory(Configuration configuration) {
     try {
       FileContext fc = FileContext.getFileContext(configuration);
-      return new FileContextLocationFactory(configuration, fc, fc.getHomeDirectory().toUri().getPath());
+      String basePath = fc.getHomeDirectory().toUri().getPath();
+      return new FileContextLocationFactory(configuration, basePath);
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }

--- a/twill-yarn/src/test/java/org/apache/twill/filesystem/LocalLocationTest.java
+++ b/twill-yarn/src/test/java/org/apache/twill/filesystem/LocalLocationTest.java
@@ -18,25 +18,14 @@
 package org.apache.twill.filesystem;
 
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  *
  */
 public class LocalLocationTest extends LocationTestBase {
-
-  @Override
-  protected String getUserName() {
-    return System.getProperty("user.name");
-  }
-
-  @Override
-  protected String getUserGroup(String groupName) {
-    String newGroup = System.getProperty("new.group.name");
-    return newGroup != null ? newGroup : groupName;
-  }
 
   @Override
   protected LocationFactory createLocationFactory(String pathBase) throws Exception {
@@ -46,13 +35,9 @@ public class LocalLocationTest extends LocationTestBase {
     return new LocalLocationFactory(basePath);
   }
 
-  protected LocationFactory createLocationFactory(String pathBase, UserGroupInformation ugi) throws Exception {
-    return null;
-  }
-
   @Override
-  public void testHomeLocation() throws Exception {
-    // For Local location, UGI won't take an effect.
-    Assert.assertEquals(System.getProperty("user.name"), createLocationFactory("/").getHomeLocation().getName());
+  protected UserGroupInformation createTestUGI() throws IOException {
+    // In local location, UGI is not supported, hence using the current user as the testing ugi.
+    return UserGroupInformation.getCurrentUser();
   }
 }

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/TwillTester.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/TwillTester.java
@@ -207,7 +207,8 @@ public class TwillTester extends ExternalResource {
   public LocationFactory createLocationFactory() {
     try {
       FileContext fc = FileContext.getFileContext(config);
-      return new FileContextLocationFactory(config, fc, fc.getHomeDirectory().toUri().getPath());
+      String basePath = fc.getHomeDirectory().toUri().getPath();
+      return new FileContextLocationFactory(config, basePath);
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }


### PR DESCRIPTION
- Use different FileContext object based on the caller UGI
- Allows sharing the same factory instance for different user