### PR TITLE
(TWILL-230) Get resource report based on the caller user

### DIFF
--- a/twill-yarn/src/main/hadoop20/org/apache/twill/internal/yarn/Hadoop20YarnApplicationReport.java
+++ b/twill-yarn/src/main/hadoop20/org/apache/twill/internal/yarn/Hadoop20YarnApplicationReport.java
@@ -77,12 +77,12 @@ public final class Hadoop20YarnApplicationReport implements YarnApplicationRepor
 
   @Override
   public String getTrackingUrl() {
-    return report.getTrackingUrl();
+    return "http://" + report.getTrackingUrl();
   }
 
   @Override
   public String getOriginalTrackingUrl() {
-    return report.getOriginalTrackingUrl();
+    return "http://" + report.getOriginalTrackingUrl();
   }
 
   @Override

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/ResourceReportClient.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/ResourceReportClient.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
@@ -53,13 +54,14 @@ final class ResourceReportClient {
       try {
         Reader reader = new BufferedReader(new InputStreamReader(url.openStream(), Charsets.UTF_8));
         try {
-          LOG.debug("Report returned by {}", url);
+          LOG.trace("Report returned by {}", url);
           return reportAdapter.fromJson(reader);
         } finally {
           Closeables.closeQuietly(reader);
         }
-      } catch (Exception e) {
-        LOG.debug("Exception raised when getting resource report from {}.", url, e);
+      } catch (IOException e) {
+        // Just log a trace as it's ok to not able to fetch resource report
+        LOG.trace("Exception raised when getting resource report from {}.", url, e);
       }
     }
     return null;

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
@@ -344,13 +344,12 @@ final class YarnTwillController extends AbstractTwillController implements Twill
           urls.add(new URL(trackingUrl.getProtocol(), trackingUrl.getHost(),
                            trackingUrl.getPort(), path + TrackerService.PATH));
         } catch (MalformedURLException e) {
-          LOG.info("Invalid tracking URL {} from YARN application report for {}:{}", url, appName, getRunId());
+          LOG.debug("Invalid tracking URL {} from YARN application report for {}:{}", url, appName, getRunId());
         }
       }
     }
 
     if (urls.isEmpty()) {
-      LOG.debug("No valid tracking URL for YARN application {}:{}", appName, getRunId());
       return null;
     }
 

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillController.java
@@ -43,10 +43,12 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.URI;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -66,7 +68,6 @@ final class YarnTwillController extends AbstractTwillController implements Twill
   private final TimeUnit startTimeoutUnit;
   private volatile ApplicationMasterLiveNodeData amLiveNodeData;
   private ProcessController<YarnApplicationReport> processController;
-  private ResourceReportClient resourcesClient;
 
   // Thread for polling yarn for application status if application got ZK session expire.
   // Only used by the instanceUpdate/Delete method, which is from serialized call from ZK callback.
@@ -100,7 +101,6 @@ final class YarnTwillController extends AbstractTwillController implements Twill
     this.startTimeout = startTimeout;
     this.startTimeoutUnit = startTimeoutUnit;
   }
-
 
   /**
    * Sends a message to application to notify the secure store has be updated.
@@ -140,14 +140,6 @@ final class YarnTwillController extends AbstractTwillController implements Twill
       if (state != YarnApplicationState.RUNNING) {
         LOG.info("Yarn application {} {} is not in running state. Shutting down controller.", appName, appId);
         forceShutDown();
-      } else {
-        try {
-          URL resourceUrl = URI.create(String.format("http://%s:%d", report.getHost(), report.getRpcPort()))
-                               .resolve(TrackerService.PATH).toURL();
-          resourcesClient = new ResourceReportClient(resourceUrl);
-        } catch (IOException e) {
-          resourcesClient = null;
-        }
       }
     } catch (Exception e) {
       throw Throwables.propagate(e);
@@ -322,7 +314,46 @@ final class YarnTwillController extends AbstractTwillController implements Twill
 
   @Override
   public ResourceReport getResourceReport() {
-    // in case the user calls this before starting, return null
+    // Only has resource report if the app is running.
+    if (state() != State.RUNNING) {
+      return null;
+    }
+    ResourceReportClient resourcesClient = getResourcesClient();
     return (resourcesClient == null) ? null : resourcesClient.get();
+  }
+
+  /**
+   * Returns the {@link ResourceReportClient} for fetching resource report from the AM.
+   * It first consults the RM for the tracking URL and get the resource report from there.
+   */
+  @Nullable
+  private ResourceReportClient getResourcesClient() {
+    YarnApplicationReport report = processController.getReport();
+    List<URL> urls = new ArrayList<>(2);
+
+    // Try getting the report from the proxy tracking URL as well as the original tracking URL directly
+    // This is mainly to workaround for unit-test that the proxy tracking URL doesn't work well with local address.
+    for (String url : Arrays.asList(report.getTrackingUrl(), report.getOriginalTrackingUrl())) {
+      if (url != null && !url.equals("N/A")) {
+        try {
+          URL trackingUrl = new URL(url);
+          String path = trackingUrl.getPath();
+          if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+          }
+          urls.add(new URL(trackingUrl.getProtocol(), trackingUrl.getHost(),
+                           trackingUrl.getPort(), path + TrackerService.PATH));
+        } catch (MalformedURLException e) {
+          LOG.info("Invalid tracking URL {} from YARN application report for {}:{}", url, appName, getRunId());
+        }
+      }
+    }
+
+    if (urls.isEmpty()) {
+      LOG.debug("No valid tracking URL for YARN application {}:{}", appName, getRunId());
+      return null;
+    }
+
+    return new ResourceReportClient(urls);
   }
 }

--- a/twill-yarn/src/test/resources/logback-test.xml
+++ b/twill-yarn/src/test/resources/logback-test.xml
@@ -24,6 +24,7 @@ limitations under the License.
         </encoder>
     </appender>
 
+    <logger name="org.mortbay" level="OFF" />
     <logger name="org.apache.twill" level="DEBUG" />
 
     <root level="WARN">


### PR DESCRIPTION
- Also by default get the resource report from the tracking url, then fall back to the original tracking url.