### PR TITLE
(TWILL-237) Twill is using hdfs HAUtil api that is nont-compatible wi…

### DIFF
--- a/twill-yarn/src/main/java/org/apache/twill/filesystem/FileContextLocation.java
+++ b/twill-yarn/src/main/java/org/apache/twill/filesystem/FileContextLocation.java
@@ -19,6 +19,7 @@ package org.apache.twill.filesystem;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileContext;
@@ -28,7 +29,6 @@ import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hdfs.HAUtil;
 import org.apache.hadoop.security.AccessControlException;
 
 import java.io.FileNotFoundException;
@@ -41,6 +41,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 /**
@@ -162,7 +163,8 @@ final class FileContextLocation implements Location {
     // append "port" to the path URI, while the DistributedFileSystem always use the cluster logical
     // name, which doesn't allow having port in it.
     URI uri = path.toUri();
-    if (HAUtil.isLogicalUri(locationFactory.getConfiguration(), uri)) {
+
+    if (FileContextLocationUtil.useLogicalUri(locationFactory.getConfiguration(), uri)) {
       try {
         // Need to strip out the port if in HA
         return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(),

--- a/twill-yarn/src/main/java/org/apache/twill/filesystem/FileContextLocationUtil.java
+++ b/twill-yarn/src/main/java/org/apache/twill/filesystem/FileContextLocationUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.filesystem;
+
+import com.google.common.base.Throwables;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HAUtil;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URI;
+
+/**
+ * Utility class.
+ */
+final class FileContextLocationUtil {
+
+  // To check whether logical URI is needed, hdfs.HAUtil class is used. But the class is meant for internal purposes,
+  // and in Hadoop 2.8, the method was renamed from "isLogicalUri" to "useLogicalUri". So resolve to the
+  // correct method.
+  private static final MethodHandle HA_UTIL_USE_LOGICAL_URI_HANDLE;
+
+  private static MethodHandle lookupInHAUtil(final String methodName)
+      throws NoSuchMethodException, IllegalAccessException {
+    return MethodHandles.publicLookup()
+        .findStatic(HAUtil.class, methodName,
+            MethodType.methodType(boolean.class, new Class[]{Configuration.class, URI.class}));
+  }
+
+  static {
+    MethodHandle handle;
+    try {
+      try {
+        // hadoop version < 2.8
+        handle = lookupInHAUtil("isLogicalUri");
+      } catch (NoSuchMethodException ignored) {
+        try {
+          // hadoop version = 2.8
+          handle = lookupInHAUtil("useLogicalUri");
+        } catch (NoSuchMethodException e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    } catch (IllegalAccessException e) {
+      throw Throwables.propagate(e);
+    }
+    HA_UTIL_USE_LOGICAL_URI_HANDLE = handle;
+  }
+
+  static boolean useLogicalUri(final Configuration configuration, final URI uri) {
+    try {
+      return (Boolean) HA_UTIL_USE_LOGICAL_URI_HANDLE.invoke(configuration, uri);
+    } catch (Throwable e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private FileContextLocationUtil() {
+  }
+}


### PR DESCRIPTION
…th hadoop 2.8

+ Use Java's MethodHandle (dynamic lang support) rather than Method (reflection) in FileContextLocationUtil
+ Expose static API rather than the handle itself