### PR TITLE
(TWILL-61) Fix to allow higher attempts to relaunch the app after the first attempt failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
         <jopt-simple.version>3.2</jopt-simple.version>
         <commons-compress.version>1.5</commons-compress.version>
         <hadoop20.output.dir>target/hadoop20-classes</hadoop20.output.dir>
+        <force.mac.tests>false</force.mac.tests>
     </properties>
 
     <scm>
@@ -338,6 +339,7 @@
                     <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+                        <force.mac.tests>${force.mac.tests}</force.mac.tests>
                     </systemPropertyVariables>
                     <reuseForks>false</reuseForks>
                     <reportFormat>plain</reportFormat>
@@ -353,6 +355,18 @@
     </build>
 
     <profiles>
+        <profile>
+            <!--
+                This profile is to force certain tests to run on Mac.
+                Those tests are disabled due to orphan processes left after the test run (HADOOP-12317).
+                If this profile is enabled, after the test finished, run the `jps` command
+                and delete all `TwillLauncher` processes
+            -->
+            <id>force-mac-tests</id>
+            <properties>
+                <force.mac.tests>true</force.mac.tests>
+            </properties>
+        </profile>
         <profile>
             <id>apache-release</id>
             <build>

--- a/twill-api/src/main/java/org/apache/twill/api/Configs.java
+++ b/twill-api/src/main/java/org/apache/twill/api/Configs.java
@@ -79,6 +79,18 @@ public final class Configs {
     public static final String YARN_AM_RESERVED_MEMORY_MB = "twill.yarn.am.reserved.memory.mb";
 
     /**
+     * Maximum number of attempts to run the application by YARN if there is failure.
+     */
+    public static final String YARN_MAX_APP_ATTEMPTS = "twill.yarn.max.app.attempts";
+
+    /**
+     * Interval time in milliseconds for the attempt failures validity interval in YARN. YARN only limit to
+     * the maximum attempt count for failures in the given interval.
+     */
+    public static final String YARN_ATTEMPT_FAILURES_VALIDITY_INTERVAL =
+      "twill.yarn.attempt.failures.validity.interval";
+
+    /**
      * Setting for enabling log collection.
      */
     public static final String LOG_COLLECTION_ENABLED = "twill.log.collection.enabled";

--- a/twill-core/src/main/java/org/apache/twill/internal/AbstractTwillService.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/AbstractTwillService.java
@@ -206,7 +206,7 @@ public abstract class AbstractTwillService extends AbstractExecutionThreadServic
   }
 
   /**
-   * Update the live node for the runnable.
+   * Update the live node for the service.
    *
    * @return A {@link OperationFuture} that will be completed when the update is done.
    */
@@ -216,11 +216,15 @@ public abstract class AbstractTwillService extends AbstractExecutionThreadServic
     return zkClient.setData(liveNodePath, serializeLiveNode());
   }
 
+  /**
+   * Creates the live node for the service. If the node already exists, it will be deleted before creation.
+   *
+   * @return A {@link OperationFuture} that will be completed when the creation is done.
+   */
   private OperationFuture<String> createLiveNode() {
-    String liveNodePath = getLiveNodePath();
-    LOG.info("Create live node {}{}", zkClient.getConnectString(), liveNodePath);
-    return ZKOperations.ignoreError(zkClient.create(liveNodePath, serializeLiveNode(), CreateMode.EPHEMERAL),
-                                    KeeperException.NodeExistsException.class, liveNodePath);
+    final String liveNodePath = getLiveNodePath();
+    LOG.info("Creating live node {}{}", zkClient.getConnectString(), liveNodePath);
+    return ZKOperations.createDeleteIfExists(zkClient, liveNodePath, serializeLiveNode(), CreateMode.EPHEMERAL, true);
   }
 
   private OperationFuture<String> removeLiveNode() {

--- a/twill-core/src/main/java/org/apache/twill/internal/kafka/client/SimpleKafkaConsumer.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/kafka/client/SimpleKafkaConsumer.java
@@ -340,17 +340,17 @@ final class SimpleKafkaConsumer implements KafkaConsumer {
           continue;
         }
 
-        // If offset < 0, meaning it's special offset value that needs to fetch either the earliest or latest offset
-        // from kafak server.
-        long off = offset.get();
-        if (off < 0) {
-          offset.set(getLastOffset(topicPart, off));
-        }
-
-        SimpleConsumer consumer = consumerEntry.getValue();
-
-        // Fire a fetch message request
         try {
+          // If offset < 0, meaning it's special offset value that needs to fetch either the earliest or latest offset
+          // from kafak server.
+          long off = offset.get();
+          if (off < 0) {
+            offset.set(getLastOffset(topicPart, off));
+          }
+
+          SimpleConsumer consumer = consumerEntry.getValue();
+
+          // Fire a fetch message request
           FetchResponse response = fetchMessages(consumer, offset.get());
 
           // Failure response, set consumer entry to null and let next round of loop to handle it.
@@ -364,6 +364,7 @@ final class SimpleKafkaConsumer implements KafkaConsumer {
 
             consumers.refresh(consumerEntry.getKey());
             consumerEntry = null;
+            backoff.backoff();
             continue;
           }
 

--- a/twill-yarn/src/main/hadoop23/org/apache/twill/internal/yarn/Hadoop23YarnAppClient.java
+++ b/twill-yarn/src/main/hadoop23/org/apache/twill/internal/yarn/Hadoop23YarnAppClient.java
@@ -48,14 +48,12 @@ import java.util.List;
  * </p>
  */
 @SuppressWarnings("unused")
-public final class Hadoop23YarnAppClient extends Hadoop21YarnAppClient {
+public class Hadoop23YarnAppClient extends Hadoop21YarnAppClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(Hadoop23YarnAppClient.class);
-  private final Configuration configuration;
 
   public Hadoop23YarnAppClient(Configuration configuration) {
     super(configuration);
-    this.configuration = configuration;
   }
 
   /**

--- a/twill-yarn/src/main/hadoop26/org/apache/twill/internal/yarn/Hadoop26YarnAppClient.java
+++ b/twill-yarn/src/main/hadoop26/org/apache/twill/internal/yarn/Hadoop26YarnAppClient.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.twill.internal.yarn;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
+import org.apache.twill.api.Configs;
+
+/**
+ * <p>
+ * The service implementation of {@link YarnAppClient} for Apache Hadoop 2.6 and beyond.
+ *
+ * The {@link VersionDetectYarnAppClientFactory} class will decide to return instance of this class for
+ * Apache Hadoop 2.6 and beyond.
+ * </p>
+ */
+@SuppressWarnings("unused")
+public class Hadoop26YarnAppClient extends Hadoop23YarnAppClient {
+
+  public Hadoop26YarnAppClient(Configuration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  protected void configureAppSubmissionContext(ApplicationSubmissionContext context) {
+    super.configureAppSubmissionContext(context);
+    long interval = configuration.getLong(Configs.Keys.YARN_ATTEMPT_FAILURES_VALIDITY_INTERVAL, -1L);
+    if (interval > 0) {
+      context.setAttemptFailuresValidityInterval(interval);
+    }
+  }
+}

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
@@ -165,9 +165,10 @@ public final class ApplicationMasterMain extends ServiceMain {
 
     @Override
     protected void startUp() throws Exception {
-      ZKOperations.ignoreError(
-        zkClient.create(kafkaZKPath, null, CreateMode.PERSISTENT),
-        KeeperException.NodeExistsException.class, kafkaZKPath).get();
+      // Create the ZK node for Kafka to use. If the node already exists, delete it to make sure there is
+      // no left over content from previous AM attempt.
+      LOG.info("Preparing Kafka ZK path {}{}", zkClient.getConnectString(), kafkaZKPath);
+      ZKOperations.createDeleteIfExists(zkClient, kafkaZKPath, null, CreateMode.PERSISTENT, true).get();
       kafkaServer.startAndWait();
     }
 

--- a/twill-yarn/src/main/java/org/apache/twill/internal/yarn/VersionDetectYarnAppClientFactory.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/yarn/VersionDetectYarnAppClientFactory.java
@@ -39,9 +39,13 @@ public final class VersionDetectYarnAppClientFactory implements YarnAppClientFac
           // 2.1 and 2.2 uses the same YarnAppClient
           clzName = getClass().getPackage().getName() + ".Hadoop21YarnAppClient";
           break;
-        default:
+        case HADOOP_23:
           // 2.3 and above uses the 2.3 YarnAppClient to support RM HA
           clzName = getClass().getPackage().getName() + ".Hadoop23YarnAppClient";
+          break;
+        default:
+          // Anything above 2.3 will be 2.6 and beyond
+          clzName = getClass().getPackage().getName() + ".Hadoop26YarnAppClient";
       }
       Class<YarnAppClient> clz = (Class<YarnAppClient>) Class.forName(clzName);
       return clz.getConstructor(Configuration.class).newInstance(configuration);

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/AppRecoveryTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/AppRecoveryTestRun.java
@@ -1,0 +1,189 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.twill.yarn;
+
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.twill.api.AbstractTwillRunnable;
+import org.apache.twill.api.EventHandler;
+import org.apache.twill.api.TwillApplication;
+import org.apache.twill.api.TwillController;
+import org.apache.twill.api.TwillRunner;
+import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.api.logging.LogEntry;
+import org.apache.twill.api.logging.LogHandler;
+import org.apache.twill.api.logging.PrinterLogHandler;
+import org.apache.twill.internal.yarn.YarnUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit test for application master resilience.
+ */
+public class AppRecoveryTestRun extends BaseYarnTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testAMRestart() throws Exception {
+    // Only run it with Hadoop-2.1 or above
+    Assume.assumeTrue(YarnUtils.getHadoopVersion().compareTo(YarnUtils.HadoopVersions.HADOOP_21) >= 0);
+    // Don't run this test in Mac, as there would be leftover java process (HADOOP-12317)
+    // The test can be force to run by turning on the "force-mac-tests" maven profile
+    // After the test finished, run the `jps` command and delete all `TwillLauncher` processes
+    Assume.assumeTrue(Boolean.parseBoolean(System.getProperty("force.mac.tests")) ||
+                      !System.getProperty("os.name").toLowerCase().contains("mac"));
+
+    File watchFile = TEMP_FOLDER.newFile();
+    watchFile.delete();
+
+    // Start the testing app, and wait for 4 log lines that match the pattern emitted by the event handler (AM)
+    // and from the runnable
+    final Semaphore semaphore = new Semaphore(0);
+    TwillRunner runner = getTwillRunner();
+    TwillController controller = runner.prepare(new TestApp(new TestEventHandler(watchFile)))
+      .addLogHandler(new PrinterLogHandler(new PrintWriter(System.out, true)))
+      // Use a log handler to match messages from AM and the Runnable to make sure the log collection get resumed
+      // correctly after the AM restarted
+      .addLogHandler(new LogHandler() {
+        @Override
+        public void onLog(LogEntry logEntry) {
+          String message = logEntry.getMessage();
+          if (message.equals("Container for " + TestRunnable.class.getSimpleName() + " launched")) {
+            semaphore.release();
+          } else if (message.equals("Running 0")) {
+            semaphore.release();
+          }
+        }
+      })
+      .start();
+
+    // Wait for the first attempt running
+    Assert.assertTrue(semaphore.tryAcquire(2, 2, TimeUnit.MINUTES));
+    // Touch the watchFile so that the event handler will kill the AM
+    Files.touch(watchFile);
+    // Wait for the second attempt running
+    Assert.assertTrue(semaphore.tryAcquire(2, 2, TimeUnit.MINUTES));
+
+    controller.terminate().get();
+  }
+
+  /**
+   * A {@link EventHandler} for killing the first attempt of the application.
+   */
+  public static final class TestEventHandler extends EventHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestEventHandler.class);
+
+    private File watchFile;
+
+    TestEventHandler(File watchFile) {
+      this.watchFile = watchFile;
+    }
+
+    @Override
+    public void containerLaunched(String runnableName, int instanceId, String containerId) {
+      LOG.info("Container for {} launched", runnableName);
+
+      if (containerId.contains("_01_")) {
+        final File watchFile = new File(context.getSpecification().getConfigs().get("watchFile"));
+        Thread t = new Thread() {
+          @Override
+          public void run() {
+            // Wait for the watch file to be available, then kill the process
+            while (!watchFile.exists()) {
+              Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+            }
+            Runtime.getRuntime().halt(-1);
+          }
+        };
+        t.setDaemon(true);
+        t.start();
+      }
+    }
+
+    @Override
+    protected Map<String, String> getConfigs() {
+      return Collections.singletonMap("watchFile", watchFile.getAbsolutePath());
+    }
+  }
+
+  /**
+   * Application for testing
+   */
+  public static final class TestApp implements TwillApplication {
+
+    private final EventHandler eventHandler;
+
+    public TestApp(EventHandler eventHandler) {
+      this.eventHandler = eventHandler;
+    }
+
+    @Override
+    public TwillSpecification configure() {
+      return TwillSpecification.Builder.with()
+        .setName("TestApp")
+        .withRunnable()
+        .add(new TestRunnable()).noLocalFiles()
+        .anyOrder()
+        .withEventHandler(eventHandler).build();
+    }
+  }
+
+  /**
+   * Runnable for testing
+   */
+  public static final class TestRunnable extends AbstractTwillRunnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestRunnable.class);
+
+    private final CountDownLatch stopLatch = new CountDownLatch(1);
+
+    @Override
+    public void run() {
+      long count = 0;
+      try {
+        while (!stopLatch.await(2, TimeUnit.SECONDS)) {
+          LOG.info("Running {}", count++);
+        }
+      } catch (InterruptedException e) {
+        LOG.info("Interrupted", e);
+      }
+    }
+
+    @Override
+    public void stop() {
+      stopLatch.countDown();
+    }
+  }
+}


### PR DESCRIPTION
- Delete the Kafka root zk node for the application if already exist
- Delete the AM instance zk node if already exist
- For runnables parent zk node, it is not an error if it already exist
- Enhance KafkaClient publisher / consumer to deal with Kafka cluster changes
  - When AM killed and restarted, the embedded Kafka will be running in different host and port