### PR TITLE
(TWILL-260) Upgrade version of zkclient - library that kafka is using.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
         <jcl-over-slf4j.version>1.7.2</jcl-over-slf4j.version>
         <asm.version>5.0.2</asm.version>
         <kafka.version>0.8.0</kafka.version>
+        <zkclient.version>0.10</zkclient.version>
         <zookeeper.version>3.4.5</zookeeper.version>
         <junit.version>4.11</junit.version>
         <jopt-simple.version>3.2</jopt-simple.version>
@@ -808,6 +809,11 @@
                 <version>${findbugs.jsr305.version}</version>
                 <optional>true</optional>
             </dependency>
+            <dependency>
+                <groupId>com.101tec</groupId>
+                <artifactId>zkclient</artifactId>
+                <version>${zkclient.version}</version>
+            </dependency> 
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>


### PR DESCRIPTION
- current version of zkclient (0.3) that kafka_2.10 version 0.8.0 is using is buggy
  it does not handle well sasl authenticate and connected events
  fix was done in zkclient 0.7
- instead of more invasive change of upgrading kafka (API changes)
  zkclient upgrade should be rather painless and fix issues with inability to connect when sasl is enabled
  especially with fast network that creates race condition between sasl authentication and connected zk events